### PR TITLE
Issue #7 Git commit hash can now be entered as a environment variable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -13,22 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- package org.jenkinsci.plugins.stashNotifier;
- 
-import hudson.Launcher;
+package org.jenkinsci.plugins.stashNotifier;
+
+import hudson.EnvVars;
 import hudson.Extension;
-import hudson.util.FormValidation;
+import hudson.Launcher;
 import hudson.model.AbstractBuild;
-import hudson.model.BuildListener;
 import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
 import hudson.model.Result;
 import hudson.plugins.git.util.BuildData;
-import hudson.tasks.Publisher;
-import hudson.tasks.Notifier;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Notifier;
+import hudson.tasks.Publisher;
+import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -45,14 +46,13 @@ import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.impl.conn.SingleClientConnManager;
 import org.apache.http.util.EntityUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.TrustManager;
 import javax.servlet.ServletException;
-
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.URL;
@@ -60,314 +60,342 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 
-import jenkins.model.Jenkins;
-
 /**
  * Notifies a configured Atlassian Stash server instance of build results
  * through the Stash build API.
- * <p>
+ * <p/>
  * Only basic authentication is supported at the moment.
- * 
- * @author	Georg Gruetter
+ *
+ * @author Georg Gruetter
  */
 public class StashNotifier extends Notifier {
-	
-	// attributes --------------------------------------------------------------
 
-	/** base url of Stash server, e. g. <tt>http://localhost:7990</tt>. */
-	private final String stashServerBaseUrl;
-	
-	/** name of Stash user for authentication with Stash build API. */
-	private final String stashUserName;
-	
-	/** password of Stash user for authentication with Stash build API. */
-	private final String stashUserPassword;
-	
-	/** if true, ignore exception thrown in case of an unverified SSL peer. */
-	private final boolean ignoreUnverifiedSSLPeer;
-	
-	// public members ----------------------------------------------------------
+    // attributes --------------------------------------------------------------
 
-	public BuildStepMonitor getRequiredMonitorService() {
-		return BuildStepMonitor.BUILD;
-	}
+    /**
+     * base url of Stash server, e. g. <tt>http://localhost:7990</tt>.
+     */
+    private final String stashServerBaseUrl;
 
-	@DataBoundConstructor
-	public StashNotifier(
-			String stashServerBaseUrl,
-			String stashUserName,
-			String stashUserPassword,
-			boolean ignoreUnverifiedSSLPeer) {
-		this.stashServerBaseUrl = stashServerBaseUrl;
-		this.stashUserName = stashUserName;
-		this.stashUserPassword = stashUserPassword;
-		this.ignoreUnverifiedSSLPeer 
-			= ignoreUnverifiedSSLPeer;
-	}
+    /**
+     * name of Stash user for authentication with Stash build API.
+     */
+    private final String stashUserName;
 
-	public String getStashServerBaseUrl() {
-		return stashServerBaseUrl;
-	}
+    /**
+     * password of Stash user for authentication with Stash build API.
+     */
+    private final String stashUserPassword;
 
-	public String getStashUserName() {
-		return stashUserName;
-	}
+    /**
+     * if true, ignore exception thrown in case of an unverified SSL peer.
+     */
+    private final boolean ignoreUnverifiedSSLPeer;
 
-	public String getStashUserPassword() {
-		return stashUserPassword;
-	}
-	
-	public boolean getIgnoreUnverifiedSSLPeer() {
-		return ignoreUnverifiedSSLPeer;
-	}
+    // public members ----------------------------------------------------------
 
-	@SuppressWarnings("rawtypes")
-	@Override
-	public boolean perform(
-			AbstractBuild build, 
-			Launcher launcher, 
-			BuildListener listener) {
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.BUILD;
+    }
 
-		PrintStream logger = listener.getLogger();
+    @DataBoundConstructor
+    public StashNotifier(
+            String stashServerBaseUrl,
+            String stashUserName,
+            String stashUserPassword,
+            boolean ignoreUnverifiedSSLPeer) {
+        this.stashServerBaseUrl = stashServerBaseUrl;
+        this.stashUserName = stashUserName;
+        this.stashUserPassword = stashUserPassword;
+        this.ignoreUnverifiedSSLPeer
+                = ignoreUnverifiedSSLPeer;
+    }
 
-		// exit if Jenkins root URL is not configured. Stash build API 
-		// requires valid link to build in CI system.
-		if (Jenkins.getInstance().getRootUrl() == null) {
-			logger.println(
-					"Cannot notify Stash! (Jenkins Root URL not configured)");
-			return true;
-		}
+    public String getStashServerBaseUrl() {
+        return stashServerBaseUrl;
+    }
 
-		// get the sha1 of the commit that was built
-		BuildData buildData 
-			= (BuildData) build.getAction(BuildData.class);
-		if  (buildData != null) {
-			String commitSha1 
-				= buildData.getLastBuiltRevision().getSha1String();
-			
-			HttpClient client = getHttpClient(logger); 
-			NotificationResult result;
+    public String getStashUserName() {
+        return stashUserName;
+    }
 
-			try {
-				result = notifyStash(build, commitSha1, client, listener);
-				if (result.indicatesSuccess) {
-					logger.println(
-						"Notified Stash for commit with id " 
-								+ commitSha1);
-				} else {
-					logger.println(
-					"Failed to notify Stash for commit "
-							+ commitSha1
-							+ " (" + result.message + ")");
-				}					
+    public String getStashUserPassword() {
+        return stashUserPassword;
+    }
+
+    public boolean getIgnoreUnverifiedSSLPeer() {
+        return ignoreUnverifiedSSLPeer;
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean perform(
+            AbstractBuild build,
+            Launcher launcher,
+            BuildListener listener) {
+
+        PrintStream logger = listener.getLogger();
+
+        // get the sha1 of the commit that was built
+        String commitSha1 = getCommitHash(build, listener);
+        if (commitSha1 != null) {
+            HttpClient client = getHttpClient(logger);
+            NotificationResult result;
+
+            try {
+                result = notifyStash(build, commitSha1, client, listener);
+                if (result.indicatesSuccess) {
+                    logger.println(
+                            "Notified Stash for commit with id "
+                                    + commitSha1);
+                } else {
+                    logger.println(
+                            "Failed to notify Stash for commit "
+                                    + commitSha1
+                                    + " (" + result.message + ")");
+                }
             } catch (SSLPeerUnverifiedException e) {
-	    		logger.println("SSLPeerUnverifiedException caught while "
-    				+ "notifying Stash. Make sure your SSL certificate on "
-    				+ "your Stash server is valid or check the "
-    				+ " 'Ignore unverifiable SSL certificate' checkbox in the "
-    				+ "Stash plugin configuration of this job.");
-			} catch (Exception e) {
-				logger.println(
-						"Caught exception while notifying Stash: " 
-						+ e.getMessage());
-			} finally {
-				client.getConnectionManager().shutdown();
-			}			
-		} else {
-			logger.println(
-					"found no commit info");
-		}
-		return true;
-	}
-		
-	/**
-	 * Returns the HttpClient through which the REST call is made. Uses an
-	 * unsafe X509 trust manager in case the user specified a HTTPS URL and
-	 * set the ignoreUnverifiedSSLPeer flag.
-	 * 
-	 * @param logger	the logger to log messages to
-	 * @return			the HttpClient
-	 */
-	private HttpClient getHttpClient(PrintStream logger) {
-		HttpClient client = null;
-		if (getStashServerBaseUrl().startsWith("https") 
-				&& ignoreUnverifiedSSLPeer) {
-			// add unsafe trust manager to avoid thrown
-			// SSLPeerUnverifiedException
-			try {
-				SSLContext sslContext = SSLContext.getInstance("TLS");
-				sslContext.init(
-						null, 
-						new TrustManager[] { new UnsafeX509TrustManager() }, 
-						new SecureRandom());
-				SSLSocketFactory sslSocketFactory 
-					= new SSLSocketFactory(sslContext);
-				SchemeRegistry schemeRegistry = new SchemeRegistry();
-				schemeRegistry.register(
-						new Scheme("https", 443, sslSocketFactory));
-				ClientConnectionManager connectionManager 
-					= new SingleClientConnManager(schemeRegistry);
-				client = new DefaultHttpClient(connectionManager);
-			} catch (NoSuchAlgorithmException nsae) {
-				logger.println("Couldn't establish SSL context: "
-						+ nsae.getMessage());
-			} catch (KeyManagementException kme) {
-				logger.println("Couldn't initialize SSL context: "
-						+ kme.getMessage());
-			} finally {
-				if (client == null) {
-					logger.println("Trying with safe trust manager, instead!");
-					client = new DefaultHttpClient();
-				}
-			}
-		} else {
-			client = new DefaultHttpClient();
-		}
-		return client;
-	}
+                logger.println("SSLPeerUnverifiedException caught while "
+                        + "notifying Stash. Make sure your SSL certificate on "
+                        + "your Stash server is valid or check the "
+                        + " 'Ignore unverifiable SSL certificate' checkbox in the "
+                        + "Stash plugin configuration of this job.");
+            } catch (Exception e) {
+                logger.println(
+                        "Caught exception while notifying Stash: "
+                                + e.getMessage());
+            } finally {
+                client.getConnectionManager().shutdown();
+            }
+        }
+        return true;
+    }
 
-	@Extension 
-	public static final class DescriptorImpl 
-		extends BuildStepDescriptor<Publisher> {
+    /**
+     * Retrieves the sha1 of the commit that was built using 2 methods:
+     * 1. Check environment variable 'GIT_COMMIT'
+     * 2. Fallback to old method (forcing git plugin to be used by this job)
+     * @param build
+     * @param listener
+     * @return the git commit hash or null if none is found
+     */
+    private String getCommitHash(AbstractBuild build, BuildListener listener) {
+        PrintStream logger = listener.getLogger();
+        String gitCommit = null;
 
-		public FormValidation doCheckStashServerBaseUrl(
-					@QueryParameter String value) 
-				throws IOException, ServletException {
+        // 1. Check if environment variable 'GIT_COMMIT' is filled in
+        try {
+            EnvVars environment = build.getEnvironment(listener);
+            gitCommit = environment.get("GIT_COMMIT");
+        } catch (Exception e) {
+            logger.println("Caught exception while notifying Stash: " + e.getMessage());
+        }
 
-			try {
-				new URL(value);
-				return FormValidation.ok();
-			} catch (Exception e) {
-				return FormValidation.error("Please specify a valid URL!");
-			}
-		}
+        // 2. Retrieve from GIT Plugin if environment variable is empty
+        if (gitCommit == null || gitCommit.isEmpty()) {
+            BuildData buildData = (BuildData) build.getAction(BuildData.class);
+            if (buildData != null) {
+                gitCommit = buildData.getLastBuiltRevision().getSha1String();
+            }
+        }
 
-		public FormValidation doCheckStashUserName(@QueryParameter String value)
-				throws IOException, ServletException {
+        // Check if a git commit hash is found
+        if (gitCommit == null || gitCommit.isEmpty()) {
+            logger.println("Found no commit info, please provide the GIT commit hash through the GIT_COMMIT environment variable or use the GIT Plugin.");
+            return null;
+        }
 
-			if (value.trim().equals("")) {
-				return FormValidation.error("Please specify a user name!");
-			} else {
-				return FormValidation.ok();
-			}
-		}
+        return gitCommit;
+    }
 
-		public FormValidation doCheckStashUserPassword(
-					@QueryParameter String value) 
-				throws IOException, ServletException {
+    /**
+     * Returns the HttpClient through which the REST call is made. Uses an
+     * unsafe X509 trust manager in case the user specified a HTTPS URL and
+     * set the ignoreUnverifiedSSLPeer flag.
+     *
+     * @param logger the logger to log messages to
+     * @return the HttpClient
+     */
+    private HttpClient getHttpClient(PrintStream logger) {
+        HttpClient client = null;
+        if (getStashServerBaseUrl().startsWith("https")
+                && ignoreUnverifiedSSLPeer) {
+            // add unsafe trust manager to avoid thrown
+            // SSLPeerUnverifiedException
+            try {
+                SSLContext sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(
+                        null,
+                        new TrustManager[]{new UnsafeX509TrustManager()},
+                        new SecureRandom());
+                SSLSocketFactory sslSocketFactory
+                        = new SSLSocketFactory(sslContext);
+                SchemeRegistry schemeRegistry = new SchemeRegistry();
+                schemeRegistry.register(
+                        new Scheme("https", 443, sslSocketFactory));
+                ClientConnectionManager connectionManager
+                        = new SingleClientConnManager(schemeRegistry);
+                client = new DefaultHttpClient(connectionManager);
+            } catch (NoSuchAlgorithmException nsae) {
+                logger.println("Couldn't establish SSL context: "
+                        + nsae.getMessage());
+            } catch (KeyManagementException kme) {
+                logger.println("Couldn't initialize SSL context: "
+                        + kme.getMessage());
+            } finally {
+                if (client == null) {
+                    logger.println("Trying with safe trust manager, instead!");
+                    client = new DefaultHttpClient();
+                }
+            }
+        } else {
+            client = new DefaultHttpClient();
+        }
+        return client;
+    }
 
-			if (value.trim().equals("")) {
-				return FormValidation.warning(
-						"You should use a non-empty password!");
-			} else {
-				return FormValidation.ok();
-			}
-		}
+    @Extension
+    public static final class DescriptorImpl
+            extends BuildStepDescriptor<Publisher> {
 
-		@SuppressWarnings("rawtypes")
-		public boolean isApplicable(Class<? extends AbstractProject> aClass) {
-			return true;
-		}
+        public FormValidation doCheckStashServerBaseUrl(
+                @QueryParameter String value)
+                throws IOException, ServletException {
 
-		public String getDisplayName() {
-			return "Notify Stash Instance";
-		}
+            try {
+                new URL(value);
+                return FormValidation.ok();
+            } catch (Exception e) {
+                return FormValidation.error("Please specify a valid URL!");
+            }
+        }
 
-		@Override
-		public boolean configure(
-				StaplerRequest req, 
-				JSONObject formData) throws FormException {
+        public FormValidation doCheckStashUserName(@QueryParameter String value)
+                throws IOException, ServletException {
 
-			save();
-			return super.configure(req,formData);
-		}
-	}
-	
-	// non-public members ------------------------------------------------------
-	
-	/**
-	 * Notifies the configured Stash server by POSTing the build results 
-	 * to the Stash build API.
-	 * 
-	 * @param build			the build to notify Stash of
-	 * @param commitSha1	the SHA1 of the built commit
-	 * @param client		the HTTP client with which to execute the request
-	 * @param listener		the build listener for logging
-	 */
-	@SuppressWarnings("rawtypes")
-	private NotificationResult notifyStash(
-			final AbstractBuild build,
-			final String commitSha1,
-			final HttpClient client, 
-			final BuildListener listener) throws Exception {
-		
-		HttpPost req = createRequest(build, commitSha1);
-		HttpResponse res = client.execute(req);
-		if (res.getStatusLine().getStatusCode() != 204) {
-			return NotificationResult.newFailure(
-					EntityUtils.toString(res.getEntity()));
-		} else {
-			return NotificationResult.newSuccess();
-		}
-	}
-	
-	/**
-	 * Returns the HTTP POST request ready to be sent to the Stash build API for
-	 * the given build and change set. 
-	 * 
-	 * @param build			the build to notify Stash of
-	 * @param commitSha1	the SHA1 of the commit that was built
-	 * @return				the HTTP POST request to the Stash build API
-	 */
-	@SuppressWarnings("rawtypes")
-	private HttpPost createRequest(
-			final AbstractBuild build,
-			final String commitSha1) throws Exception {
-		
-		HttpPost req = new HttpPost(
-				stashServerBaseUrl  
-				+ "/rest/build-status/1.0/commits/" 
-				+ commitSha1);
-		
-		req.addHeader(BasicScheme.authenticate(
-				new UsernamePasswordCredentials(
-						stashUserName, 
-						stashUserPassword), 
-				"UTF-8", 
-				false));
-		
-		req.addHeader("Content-type", "application/json");		
-		req.setEntity(newStashBuildNotificationEntity(build));
-				
-		return req;
-	}
-	
-	/**
-	 * Returns the HTTP POST entity body with the JSON representation of the
-	 * builds result to be sent to the Stash build API.
-	 * 
-	 * @param build			the build to notify Stash of
-	 * @return				HTTP entity body for POST to Stash build API
-	 */
-	@SuppressWarnings("rawtypes")
-	private HttpEntity newStashBuildNotificationEntity(final AbstractBuild build)
+            if (value.trim().equals("")) {
+                return FormValidation.error("Please specify a user name!");
+            } else {
+                return FormValidation.ok();
+            }
+        }
+
+        public FormValidation doCheckStashUserPassword(
+                @QueryParameter String value)
+                throws IOException, ServletException {
+
+            if (value.trim().equals("")) {
+                return FormValidation.warning(
+                        "You should use a non-empty password!");
+            } else {
+                return FormValidation.ok();
+            }
+        }
+
+        @SuppressWarnings("rawtypes")
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            return true;
+        }
+
+        public String getDisplayName() {
+            return "Notify Stash Instance";
+        }
+
+        @Override
+        public boolean configure(
+                StaplerRequest req,
+                JSONObject formData) throws FormException {
+
+            save();
+            return super.configure(req, formData);
+        }
+    }
+
+    // non-public members ------------------------------------------------------
+
+    /**
+     * Notifies the configured Stash server by POSTing the build results
+     * to the Stash build API.
+     *
+     * @param build      the build to notify Stash of
+     * @param commitSha1 the SHA1 of the built commit
+     * @param client     the HTTP client with which to execute the request
+     * @param listener   the build listener for logging
+     */
+    @SuppressWarnings("rawtypes")
+    private NotificationResult notifyStash(
+            final AbstractBuild build,
+            final String commitSha1,
+            final HttpClient client,
+            final BuildListener listener) throws Exception {
+
+        HttpPost req = createRequest(build, commitSha1);
+        HttpResponse res = client.execute(req);
+        if (res.getStatusLine().getStatusCode() != 204) {
+            return NotificationResult.newFailure(
+                    EntityUtils.toString(res.getEntity()));
+        } else {
+            return NotificationResult.newSuccess();
+        }
+    }
+
+    /**
+     * Returns the HTTP POST request ready to be sent to the Stash build API for
+     * the given build and change set.
+     *
+     * @param build      the build to notify Stash of
+     * @param commitSha1 the SHA1 of the commit that was built
+     * @return the HTTP POST request to the Stash build API
+     */
+    @SuppressWarnings("rawtypes")
+    private HttpPost createRequest(
+            final AbstractBuild build,
+            final String commitSha1) throws Exception {
+
+        HttpPost req = new HttpPost(
+                stashServerBaseUrl
+                        + "/rest/build-status/1.0/commits/"
+                        + commitSha1);
+
+        req.addHeader(BasicScheme.authenticate(
+                new UsernamePasswordCredentials(
+                        stashUserName,
+                        stashUserPassword),
+                "UTF-8",
+                false));
+
+        req.addHeader("Content-type", "application/json");
+        req.setEntity(newStashBuildNotificationEntity(build));
+
+        return req;
+    }
+
+    /**
+     * Returns the HTTP POST entity body with the JSON representation of the
+     * builds result to be sent to the Stash build API.
+     *
+     * @param build the build to notify Stash of
+     * @return HTTP entity body for POST to Stash build API
+     */
+    @SuppressWarnings("rawtypes")
+    private HttpEntity newStashBuildNotificationEntity(final AbstractBuild build)
             throws Exception {
 
         JSONObject json = new JSONObject();
 
-        if ((build.getResult() == null) 
-        		|| (!build.getResult().equals(Result.SUCCESS))) {
+        if ((build.getResult() == null)
+                || (!build.getResult().equals(Result.SUCCESS))) {
             json.put("state", "FAILED");
         } else {
             json.put("state", "SUCCESSFUL");
         }
 
         json.put(
-        		"key",
-        		StringEscapeUtils.escapeJavaScript(
-        				build.getProject().getName()) + "-" + 
-        				build.getNumber() + "-" + 
-        				Jenkins.getInstance().getRootUrl());
+                "key",
+                StringEscapeUtils.escapeJavaScript(
+                        build.getProject().getName()) + "-" +
+                        build.getNumber() + "-" +
+                        Jenkins.getInstance().getRootUrl());
 
         // This is to replace the odd character Jenkins injects to separate 
         // nested jobs, especially when using the Cloudbees Folders plugin. 
@@ -381,5 +409,5 @@ public class StashNotifier extends Notifier {
                 "built by Jenkins @ ".concat(Jenkins.getInstance().getRootUrl()));
         json.put("url", Jenkins.getInstance().getRootUrl().concat(build.getUrl()));
         return new StringEntity(json.toString());
-	}
+    }
 }


### PR DESCRIPTION
Per my Issue #7 this is how I fixed it and this is running on our Jenkins server.
In essence it's an easy change, just adding a check of the environment variables.
1. Check the environment variables for GIT_COMMIT
2. Fallback to Git Plugin to retrieve commit hash

Ps: Intellij reformatted the code resulting in a lot more changes than required.
