### PR TITLE
Pr/20

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -135,7 +135,7 @@ public class StashNotifier extends Notifier {
 	}
 
 	public String getStashUserPassword() {
-		return Secret.toString(stashUserPassword);
+		return stashUserPassword.getEncryptedValue();
 	}
 	
 	public boolean getIgnoreUnverifiedSSLPeer() {


### PR DESCRIPTION
the password field in the web form is now populated with the encrypted value rather than the plain text value. Together with the previous commit from Chuck, this should fix issue #19 .
