### PR TITLE
Allow parallel builds. This change keeps Stash Notifier from blocking wa...

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -109,7 +109,7 @@ public class StashNotifier extends Notifier {
 	// public members ----------------------------------------------------------
 
 	public BuildStepMonitor getRequiredMonitorService() {
-		return BuildStepMonitor.BUILD;
+		return BuildStepMonitor.NONE;
 	}
 
 	@DataBoundConstructor


### PR DESCRIPTION
Allow parallel builds. This change keeps Stash Notifier from blockiting for a checkpoint when another build for the same project is running.

Its not my change but could you pull it..
We have the same problem and its sometimes waiting hour to finish other job..
