### PR TITLE
Fix grammar and indentation a bit

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-commitSha1.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-commitSha1.html
@@ -1,6 +1,6 @@
 <div>
-  Enter a 40-digit SHA1 commit id or the Jenkins variable prefixed with '$'
-  (e. g. <em>$GIT_COMMIT</em>) when you want a the notification to be 
+  Enter a 40-digit SHA1 commit id or a Jenkins variable prefixed with '$'
+  (e. g. <em>$GIT_COMMIT</em>) when you want the notification to be
   attached to a specific commit in Stash. If left empty, Jenkins will use the
-  commit that was build by the git plugin.
+  commit that was built by the Git plugin.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-ignoreUnverifiedSSLPeer.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-ignoreUnverifiedSSLPeer.html
@@ -1,2 +1,2 @@
-Check this if you need to connect to Stash server via https which uses an 
-invalid or self signed SSL certificate
+Check this if you need to connect by HTTPS to a Stash server that uses an
+invalid or self-signed SSL certificate

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-stashServerBaseUrl.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-stashServerBaseUrl.html
@@ -1,7 +1,7 @@
 <div>
   The base URL of the Stash server to notify. Examples are:
   <ul>
-  <li><tt>http://localhost:7990</tt>, or</li>
-  <li><tt>http://my.company.intranet/stash</tt>.</li>
+    <li><tt>http://localhost:7990</tt>, or</li>
+    <li><tt>http://my.company.intranet/stash</tt>.</li>
   </ul>
 </div>

--- a/src/main/webapp/help-globalConfig-ignoreUnverifiedSSL.html
+++ b/src/main/webapp/help-globalConfig-ignoreUnverifiedSSL.html
@@ -1,6 +1,6 @@
 <div>
   <p>
-  Check this if you need to connect to Stash server via https which uses an 
-invalid or self signed SSL certificate.
+    Check this if you need to connect by HTTPS to a Stash server that uses an
+    invalid or self-signed SSL certificate.
   </p>
 </div>

--- a/src/main/webapp/help-globalConfig-stashRootUrl.html
+++ b/src/main/webapp/help-globalConfig-stashRootUrl.html
@@ -1,9 +1,9 @@
 <div>
   <p>
-  The base URL of the Stash server to notify. Examples are:
+    The base URL of the Stash server to notify. Examples are:
     <ul>
-    <li><tt>http://localhost:7990</tt>, or</li>
-    <li><tt>http://my.company.intranet/stash</tt>.</li>
+      <li><tt>http://localhost:7990</tt>, or</li>
+      <li><tt>http://my.company.intranet/stash</tt>.</li>
     </ul>
   </p>
 </div>


### PR DESCRIPTION
I read the plugin source to understand how it deals with an environment variable in the custom SHA1 field and decided to fix some grammar along the way :) I'm not a native English speaker, but I have a certificate of advanced level English training. Hope this helps.
