### PR TITLE
Fix for build issues when the job description has "invalid" characters.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -627,7 +627,7 @@ public class StashNotifier extends Notifier {
                 replaceAll("\\\\u00BB", "\\/");
         json.put("name", fullName);
 
-        json.put("description", getBuildDescription(build, state));
+        json.put("description", StringEscapeUtils.escapeJavaScript(getBuildDescription(build, state)));
         json.put("url", Jenkins.getInstance()
         		.getRootUrl().concat(build.getUrl()));
         


### PR DESCRIPTION
I had some problems with the StashNotifier. On some builds the INPROGRESS worked but the SUCCESSFUL not. After looking into the differences, the thing I found was that the jobs which weren't placed on SUCCESSFUL had a custom build description which among others had "/" in it.

This change should fix it!

(somehow I can't use the plugin when I build it myself: class org.jenkinsci.plugins.stashNotifier.StashNotifier is missing its descriptor)