### PR TITLE
Fix for issue #46 - allow SNI and update HttpClient to version 4.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.1</version>
+			<version>4.3.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkinsci.plugins</groupId>


### PR DESCRIPTION
My attempted to move to HttpClient 4.3.x which gives SNI to stop SSL errors (even when unsecure is used) because the sever IP is hosting multiple HTTPS domains. 

Fixes issue #46 