### PR TITLE
Notify with commit that triggered the build with using "Merge before build".

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,9 @@
 			<version>4.1</version>
 		</dependency>
 		<dependency>
-			<groupId>org.jenkinsci.plugins</groupId>
+			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>git</artifactId>
-			<version>1.1.26</version>
+			<version>2.0</version>
 			<type>jar</type>
 		</dependency>
 	</dependencies>

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -259,10 +259,20 @@ public class StashNotifier extends Notifier {
 		// MultiSCM may add multiple BuildData actions for each SCM, but we are covered in any case
 		for (BuildData buildData : build.getActions(BuildData.class)) {
 			// get the sha1 of the commit that was built
-			String sha1 = buildData.getLastBuiltRevision().getSha1String();
+
+			String lastBuiltSha1 = buildData.getLastBuiltRevision().getSha1String();
+
 			// Should never be null, but may be blank
-			if (!sha1.isEmpty()) {
-				sha1s.add(sha1);
+			if (!lastBuiltSha1.isEmpty()) {
+				sha1s.add(lastBuiltSha1);
+			}
+
+			// This might be different than the lastBuiltSha1 if using "Merge before build"
+			String markedSha1 = buildData.lastBuild.getMarked().getSha1String();
+
+			// Should never be null, but may be blank
+			if (!markedSha1.isEmpty()) {
+				sha1s.add(markedSha1);
 			}
 		}
 		return sha1s;


### PR DESCRIPTION
Currently, if you use the "Merge before build" option in the Git plugin then the stash notifier plugin send the commit id of the merge to stash which means that the pull request never gets the build status.  This change just sends both the merge commit and the original commit to Stash.

I had to modify the version of Jenkins and the Git plugin in order to get this to work as I expected.  Not sure if that is a problem or not.  Also, it might make more sense to make this a configurable option but this is my first time working on a Jenkins plugin so I didn't get that far into it at this point.