### PR TITLE
Changed encoding from ISO_8859_1 (ASCII) to UTF-8 which makes it possible to use text from different languages in the build description

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -642,7 +642,7 @@ public class StashNotifier extends Notifier {
         json.put("url", Jenkins.getInstance()
         		.getRootUrl().concat(build.getUrl()));
         
-        return new StringEntity(json.toString());
+        return new StringEntity(json.toString(), "UTF-8");
 	}
 
 	/**


### PR DESCRIPTION
I noticed that the stash notifier plug-in correctly send the start of a build to Stash, but never was able to tell Stashit is finished.
After troubleshooting this issue, I found that having a German umlaut in the generated jenkins job build-description, when I removed this everything works just fine.

The error was in the StringEntity, which is used to send the content of the notification to Stash, without specifying a encoding plain text (ASCII) is used.
But our content had a German umlaut, and needs other encoding.

By specifying the encoding (actually the StringEntity calls it charset) this fixes our problem.
As Stash supports (actually prefers) UTF-8 and UTF-8 > ASCII, this should not only solve the usage of German but also most other languages.

I don't see a down-side of this change...