### PR TITLE
Enhanced project keys

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
@@ -19,11 +19,17 @@
    <f:entry title="Commit SHA-1" field="commitSha1">
     <f:textbox />
   </f:entry>
-   <f:entry title="Ignore unverified SSL certificates" 
+   <f:entry title="Ignore unverified SSL certificates"
    		field="ignoreUnverifiedSSLPeer">
     <f:checkbox />
   </f:entry>
   <f:entry title="Keep repeated builds in Stash" field="includeBuildNumberInKey">
+    <f:checkbox />
+  </f:entry>
+  <f:entry title="Override project key" field="projectKey">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="Prepend parent project name to key" field="prependParentProjectKey">
     <f:checkbox />
   </f:entry>
  </f:advanced>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
@@ -25,5 +25,10 @@
                help="${rootURL}/plugin/stashNotifier/help-globalConfig-includeBuildNumberInKey.html">
           <f:checkbox />
       </f:entry>
+      <f:entry title="Prepend parent project name to key"
+               field="prependParentProjectKey"
+               help="${rootURL}/plugin/stashNotifier/help-globalConfig-prependParentProjectKey.html">
+          <f:checkbox />
+      </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-prependParentProjectKey.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-prependParentProjectKey.html
@@ -1,0 +1,3 @@
+<div>
+  Whether to prepend parent project while forming notify key
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-projectKey.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-projectKey.html
@@ -1,0 +1,3 @@
+<div>
+  If not empty, this key will be used instead of automatically configured project key
+</div>

--- a/src/main/webapp/help-globalConfig-prependParentProjectKey.html
+++ b/src/main/webapp/help-globalConfig-prependParentProjectKey.html
@@ -1,0 +1,6 @@
+<div>
+  <p>
+    Check this if you want to prepend parent project when forming project key while notifying stash. This is made for
+      compatability with older version and unchecked by default. This is useful for subproject with the same name (like modules)
+  </p>
+</div>

--- a/src/main/webapp/help-globalConfig-projectKey.html
+++ b/src/main/webapp/help-globalConfig-projectKey.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+      Override project key for all notifies
+  </p>
+</div>

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
@@ -42,7 +42,9 @@ public class StashNotifierTest
 			"tiger",
 			true,
 			null,
-			true
+			true,
+			null,
+			false
 		);
 	}
 


### PR DESCRIPTION
Here is implementation for two options 

* Custom persist project key for a job (Fix #36 )
* Option to prepend parent project name for nested project (i.e maven subprojects). This helps to different jobs operating subprojects with same name to keep different notifications instead of overriding each other.

All changes should be BC as disabled on empty (by default). All changes built and tested on my own jenkins installation.