### PR TITLE
Allow cleanup 'old' builds in Stash after successful build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -325,20 +325,15 @@ public class StashNotifier extends Notifier {
 	 * @return			the HttpClient
 	 */
 	private HttpClient getHttpClient(PrintStream logger) throws Exception {
-        boolean ignoreUnverifiedSSL = ignoreUnverifiedSSLPeer;
         String stashServer = stashServerBaseUrl;
         DescriptorImpl descriptor = getDescriptor();
         if ("".equals(stashServer) || stashServer == null) {
             stashServer = descriptor.getStashRootUrl();
         }
-        if (!ignoreUnverifiedSSL) {
-            ignoreUnverifiedSSL = descriptor.isIgnoreUnverifiedSsl();
-        }
 
         URL url = new URL(stashServer);
         HttpClientBuilder builder = HttpClientBuilder.create();
-        if (url.getProtocol().equals("https")
-                && ignoreUnverifiedSSL) {
+        if (ignoreUnverifiedSSLPeer && url.getProtocol().equals("https")) {
 			// add unsafe trust manager to avoid thrown
 			// SSLPeerUnverifiedException
 			try {
@@ -613,8 +608,7 @@ public class StashNotifier extends Notifier {
 		
 		try {
 			// first collect all existing builds if cleanup old previous builds is required
-			if ((cleanupBuildsOnSuccess || getDescriptor().isCleanupBuildsOnSuccess())
-					&& StashBuildState.SUCCESSFUL.equals(state)) {
+			if (cleanupBuildsOnSuccess && StashBuildState.SUCCESSFUL.equals(state)) {
 				logger.println("Cleaning previous builds for " + commitSha1);
 				HttpGet req = createGetRequest(commitSha1);
 				HttpResponse res = client.execute(req);
@@ -801,8 +795,7 @@ public class StashNotifier extends Notifier {
 		StringBuilder key = new StringBuilder();
 
 		key.append(build.getProject().getName());
-		if (includeBuildNumberInKey
-				|| getDescriptor().isIncludeBuildNumberInKey()) {
+		if (includeBuildNumberInKey) {
 			key.append('-').append(build.getNumber());
 		}
 		key.append('-').append(Jenkins.getInstance().getRootUrl());
@@ -822,7 +815,7 @@ public class StashNotifier extends Notifier {
 
 		StringBuilder key = new StringBuilder();
 
-		if (prependParentProjectKey || getDescriptor().isPrependParentProjectKey()){
+		if (prependParentProjectKey){
 			if (null != build.getParent().getParent()) {
 				key.append(build.getParent().getParent().getFullName()).append('-');
 			}

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
@@ -26,6 +26,9 @@
   <f:entry title="Keep repeated builds in Stash" field="includeBuildNumberInKey">
     <f:checkbox />
   </f:entry>
+  <f:entry title="Cleanup Stash builds on success" field="cleanupBuildsOnSuccess">
+    <f:checkbox />
+  </f:entry>
   <f:entry title="Override project key" field="projectKey">
     <f:textbox />
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
@@ -21,19 +21,19 @@
   </f:entry>
    <f:entry title="Ignore unverified SSL certificates"
    		field="ignoreUnverifiedSSLPeer">
-    <f:checkbox />
+    <f:checkbox default="${descriptor.isIgnoreUnverifiedSsl()}" />
   </f:entry>
   <f:entry title="Keep repeated builds in Stash" field="includeBuildNumberInKey">
-    <f:checkbox />
+    <f:checkbox default="${descriptor.isIncludeBuildNumberInKey()}" />
   </f:entry>
   <f:entry title="Cleanup Stash builds on success" field="cleanupBuildsOnSuccess">
-    <f:checkbox />
+    <f:checkbox default="${descriptor.isCleanupBuildsOnSuccess()}" />
   </f:entry>
   <f:entry title="Override project key" field="projectKey">
     <f:textbox />
   </f:entry>
   <f:entry title="Prepend parent project name to key" field="prependParentProjectKey">
-    <f:checkbox />
+    <f:checkbox default="${descriptor.isPrependParentProjectKey()}" />
   </f:entry>
  </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
@@ -25,6 +25,11 @@
                help="${rootURL}/plugin/stashNotifier/help-globalConfig-includeBuildNumberInKey.html">
           <f:checkbox />
       </f:entry>
+	  <f:entry title="Cleanup Stash builds on success" 
+	  		   field="cleanupBuildsOnSuccess"
+	  		   help="${rootURL}/plugin/stashNotifier/help-globalConfig-cleanupBuildsOnSuccess.html">
+    	  <f:checkbox />
+  	  </f:entry>
       <f:entry title="Prepend parent project name to key"
                field="prependParentProjectKey"
                help="${rootURL}/plugin/stashNotifier/help-globalConfig-prependParentProjectKey.html">

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-cleanupBuildsOnSuccess.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-cleanupBuildsOnSuccess.html
@@ -1,0 +1,7 @@
+<div>
+	<p>
+		Cleanup Stash builds after a successful build. This is used to mitigate a flaw in 
+		Stash were merging is not possible if a build wasn't successful even if the last 
+		build was successful.
+	</p>
+</div>

--- a/src/main/webapp/help-globalConfig-cleanupBuildsOnSuccess.html
+++ b/src/main/webapp/help-globalConfig-cleanupBuildsOnSuccess.html
@@ -1,0 +1,7 @@
+<div>
+	<p>
+		Cleanup Stash builds after a successful build. This is used to mitigate a flaw in 
+		Stash were merging is not possible if a build wasn't successful even if the last 
+		build was successful.
+	</p>
+</div>

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
@@ -43,6 +43,7 @@ public class StashNotifierTest
 			true,
 			null,
 			true,
+			false,
 			null,
 			false
 		);


### PR DESCRIPTION
Stash has an issue that if you've set a requirement of minimum 1 successful build for pull requests to merge, you won't be able to merge it when a it contains a failed build. Even if the last build was successful!

You can mitigate this problem by either pushing a new commit in the pull request, causing the builds to 'disappear' since you've changed the commit, or change the statuses of those old builds to success (unfortunately Stash REST API doesn't allow you to remove them). The latter is what I included in this pull request.

You could argue that you can solve this by not enabling the feature 'Keep repeated builds in Stash', but this won't solve your problem if you have multiple Jenkins instances notifying Stash. Plus, you might want to see a reference to all builds for verification afterwards.