### PR TITLE
Fix the issue when connect the SSL stash server via an http proxy.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -51,6 +51,7 @@ import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLContextBuilder;
 import org.apache.http.conn.ssl.SSLContexts;
@@ -365,6 +366,7 @@ public class StashNotifier extends Notifier {
 				Registry<ConnectionSocketFactory> registry
 						= RegistryBuilder.<ConnectionSocketFactory>create()
 							.register("https", sslConnSocketFactory)
+							.register("http", PlainConnectionSocketFactory.INSTANCE)
 							.build();
 
 				HttpClientConnectionManager ccm


### PR DESCRIPTION
This fixes the following connection setting. Which is mentioned in the issue #57 
```
stash notifier plugin <-> http proxy <-> stash server with https
```