### PR TITLE
Computer.CONFIGURE doesn't seem to be the premissions that are requir…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -495,7 +495,7 @@ public class StashNotifier extends Notifier {
         }
 
 		public ListBoxModel doFillCredentialsIdItems(@AncestorInPath ItemGroup context) {
-            if (!(context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance()).hasPermission(Computer.CONFIGURE)) {
+            if (!(context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getInstance()).hasPermission(Item.CONFIGURE)) {
 				return new ListBoxModel();
 			}
 


### PR DESCRIPTION
#86

Computer.CONFIGURE doesn't seem to be the premissions that are required (see javadoc: http://javadoc.jenkins-ci.org/hudson/model/Computer.html)

The Item.CONFIGURE seem to be the appropriate ones (see javadoc: http://javadoc.jenkins-ci.org/hudson/model/Item.html). We are checking if the user has permissions to configure the Item where the StashNotifier post build step has been added, right?

This also seem to correspond (roughly) to how the Git SCM plugin does its checks.
         
In any case this seems to fix the issue on my local setup (cloudbees folder + project matrix based security + local jenkins user database).