### PR TITLE
Unit tests for stashnotifier-plugin to increase code coverage from 37%to 82

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/NotificationResult.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/NotificationResult.java
@@ -58,7 +58,7 @@ public final class NotificationResult {
 	 * @param initSuccess	success flag
 	 * @param initMessage 	message in case notification was not successful
 	 */
-	private NotificationResult(
+	protected NotificationResult(
 			final boolean initSuccess, 
 			final String initMessage) {
 		

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -277,7 +277,7 @@ public class StashNotifier extends Notifier {
 		return true;
 	}
 
-	private Collection<String> lookupCommitSha1s(
+    protected Collection<String> lookupCommitSha1s(
 			@SuppressWarnings("rawtypes") AbstractBuild build,
 			BuildListener listener) {
 
@@ -468,8 +468,12 @@ public class StashNotifier extends Notifier {
 		private boolean prependParentProjectKey;
 		private boolean disableInprogressNotification;
 
-		public DescriptorImpl() {
-            load();
+        public DescriptorImpl() {
+            this(true);
+        }
+
+        protected DescriptorImpl(boolean load) {
+            if (load) load();
         }
 
 		public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item project) {
@@ -608,7 +612,7 @@ public class StashNotifier extends Notifier {
 	 * @param listener		the build listener for logging
 	 * @param state			the state of the build as defined by the Stash API.
 	 */
-	private NotificationResult notifyStash(
+	protected NotificationResult notifyStash(
 			final PrintStream logger,
 			final AbstractBuild<?, ?> build,
 			final String commitSha1,
@@ -680,7 +684,7 @@ public class StashNotifier extends Notifier {
 	 * @param commitSha1	the SHA1 of the commit that was built
 	 * @return				the HTTP POST request to the Stash build API
 	 */
-	private HttpPost createRequest(
+    protected HttpPost createRequest(
 			final HttpEntity stashBuildNotificationEntity,
             final Item project,
 			final String commitSha1) {
@@ -788,7 +792,7 @@ public class StashNotifier extends Notifier {
 	 * @param 	build	the build to notify Stash of
 	 * @return	the build key for the Stash notification
 	 */
-	private String getBuildKey(final AbstractBuild<?, ?> build,
+	protected String getBuildKey(final AbstractBuild<?, ?> build,
 							   BuildListener listener) {
 
 		StringBuilder key = new StringBuilder();
@@ -833,7 +837,7 @@ public class StashNotifier extends Notifier {
 	 * @param state		the state of the build
 	 * @return			the description of the build
 	 */
-	private String getBuildDescription(
+	protected String getBuildDescription(
 			final AbstractBuild<?, ?> build,
 			final StashBuildState state) {
 

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
@@ -1,0 +1,144 @@
+package org.jenkinsci.plugins.stashNotifier;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import hudson.model.AbstractProject;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.security.ACL;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import net.sf.json.JSONObject;
+import org.acegisecurity.Authentication;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kohsuke.stapler.StaplerRequest;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by Vlad Medvedev on 27.01.2016.
+ * vladislav.medvedev@devfactory.com
+ */
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({StashNotifier.DescriptorImpl.class, com.cloudbees.plugins.credentials.CredentialsProvider.class})
+public class DescriptorImplTest {
+    private JSONObject json;
+
+    @Before
+    public void setUp() {
+        json = new JSONObject();
+        json.put("stashRootUrl", "http://stash-root-url");
+        json.put("credentialsId", "someCredentialsId");
+        json.put("projectKey", "someProjectKey");
+        json.put("ignoreUnverifiedSsl", "true");
+        json.put("includeBuildNumberInKey", "true");
+        json.put("prependParentProjectKey", "true");
+        json.put("disableInprogressNotification", "true");
+    }
+
+    @Test
+    public void testConfigure() throws Descriptor.FormException {
+        //given
+        StashNotifier.DescriptorImpl desc = spy(new StashNotifier.DescriptorImpl(false));
+        doNothing().when(desc).save();
+
+        //when
+        desc.configure(mock(StaplerRequest.class), json);
+
+        //then
+        assertThat(desc.getStashRootUrl(), is("http://stash-root-url"));
+        assertThat(desc.getCredentialsId(), is("someCredentialsId"));
+        assertThat(desc.getProjectKey(), is("someProjectKey"));
+        assertThat(desc.getDisplayName(), is("Notify Stash Instance"));
+        assertThat(desc.isDisableInprogressNotification(), is(true));
+        assertThat(desc.isIgnoreUnverifiedSsl(), is(true));
+        assertThat(desc.isIncludeBuildNumberInKey(), is(true));
+        assertThat(desc.isPrependParentProjectKey(), is(true));
+        assertThat(desc.isApplicable(AbstractProject.class), is(true));
+    }
+
+    @Test
+    public void test_doFillCredentialsIdItems_project_null() {
+        StashNotifier.DescriptorImpl desc = spy(new StashNotifier.DescriptorImpl(false));
+        ListBoxModel listBoxModel = desc.doFillCredentialsIdItems(null);
+
+        assertThat(listBoxModel, is(not(nullValue())));
+    }
+
+    @Test
+    public void test_doFillCredentialsIdItems_no_permission() {
+        StashNotifier.DescriptorImpl desc = spy(new StashNotifier.DescriptorImpl(false));
+        Item project = mock(Item.class);
+        when(project.hasPermission(eq(Item.CONFIGURE))).thenReturn(false);
+
+        ListBoxModel listBoxModel = desc.doFillCredentialsIdItems(project);
+        assertThat(listBoxModel, is(not(nullValue())));
+    }
+
+    @Test
+    public void test_doFillCredentialsIdItems_has_permission() {
+        //given
+        Item project = mock(Item.class);
+        StashNotifier.DescriptorImpl desc = spy(new StashNotifier.DescriptorImpl(false));
+        when(project.hasPermission(eq(Item.CONFIGURE))).thenReturn(true);
+        PowerMockito.mockStatic(com.cloudbees.plugins.credentials.CredentialsProvider.class);
+        PowerMockito.when(com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials(
+                Mockito.<Class>anyObject(),
+                Mockito.<Item>anyObject(),
+                Mockito.<Authentication>anyObject(),
+                Mockito.<ArrayList<DomainRequirement>>anyObject())).thenReturn(new ArrayList());
+
+        //when
+        ListBoxModel listBoxModel = desc.doFillCredentialsIdItems(project);
+
+        //then
+        assertThat(listBoxModel, is(not(nullValue())));
+    }
+
+    private FormValidation doCheckStashServerBaseUrl(String url) throws IOException, ServletException {
+        //given
+        Item project = mock(Item.class);
+        StashNotifier.DescriptorImpl desc = spy(new StashNotifier.DescriptorImpl(false));
+        when(project.hasPermission(eq(Item.CONFIGURE))).thenReturn(true);
+        PowerMockito.mockStatic(com.cloudbees.plugins.credentials.CredentialsProvider.class);
+        PowerMockito.when(com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials(
+                Mockito.<Class>anyObject(),
+                Mockito.<Item>anyObject(),
+                Mockito.<Authentication>anyObject(),
+                Mockito.<ArrayList<DomainRequirement>>anyObject())).thenReturn(new ArrayList());
+
+        return desc.doCheckStashServerBaseUrl(url);
+    }
+
+    @Test
+    public void test_doCheckStashServerBaseUrl_empty() throws IOException, ServletException {
+        FormValidation listBoxModel = doCheckStashServerBaseUrl("");
+        assertThat(listBoxModel.kind, is(FormValidation.Kind.ERROR));
+    }
+
+    @Test
+    public void test_doCheckStashServerBaseUrl() throws IOException, ServletException {
+        FormValidation listBoxModel = doCheckStashServerBaseUrl("http://some-stash-url");
+        assertThat(listBoxModel.kind, is(FormValidation.Kind.OK));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
@@ -1,32 +1,42 @@
 package org.jenkinsci.plugins.stashNotifier;
 
 import com.cloudbees.plugins.credentials.Credentials;
+import com.cloudbees.plugins.credentials.CredentialsMatcher;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import hudson.EnvVars;
+import hudson.Launcher;
 import hudson.ProxyConfiguration;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
-import hudson.model.Item;
+import hudson.model.*;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.util.Build;
 import hudson.plugins.git.util.BuildData;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
+import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthenticationStrategy;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.hamcrest.CoreMatchers;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,101 +49,104 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.io.PrintStream;
-import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Secret.class, Jenkins.class, HttpClientBuilder.class})
+@PrepareForTest({Secret.class, Jenkins.class, HttpClientBuilder.class, TokenMacro.class, CredentialsMatchers.class})
 @PowerMockIgnore("javax.net.ssl.*")
-public class StashNotifierTest
-{
-	final static String sha1 = "1234567890123456789012345678901234567890";
-	private HttpClientBuilder httpClientBuilder;
-	private Jenkins jenkins;
+public class StashNotifierTest {
+    final static String sha1 = "1234567890123456789012345678901234567890";
+    private HttpClientBuilder httpClientBuilder;
+    private Jenkins jenkins;
 
-	public StashNotifier buildStashNotifier(String stashBaseUrl) {
-		return new StashNotifier(
-				stashBaseUrl,
-				"scot",
-				true,
-				null,
-				true,
-				null,
-				false,
-				false);
-	}
+    public StashNotifier buildStashNotifier() {
+        return new StashNotifier(
+                "http://localhost",
+                "scot",
+                true,
+                null,
+                true,
+                null,
+                false,
+                false);
+    }
 
-	StashNotifier sn;
-	BuildListener buildListener;
-	AbstractBuild<?,?> build;
+    StashNotifier sn;
+    BuildListener buildListener;
+    AbstractBuild<?, ?> build;
 
-	@Before
-	public void setUp() throws IOException, InterruptedException {
-		PowerMockito.mockStatic(Secret.class);
-		PowerMockito.mockStatic(Jenkins.class);
-		PowerMockito.mockStatic(HttpClientBuilder.class);
+    @Before
+    public void setUp() throws IOException, InterruptedException {
+        PowerMockito.mockStatic(Secret.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.mockStatic(HttpClientBuilder.class);
 
-		buildListener = mock(BuildListener.class);
-		jenkins = mock(Jenkins.class);
-		build = mock(AbstractBuild.class);
-		AbstractProject project = mock(AbstractProject.class);
-		EnvVars environment = mock(EnvVars.class);
-		PrintStream logger = System.out;
-		Secret secret = mock(Secret.class);
-		httpClientBuilder = PowerMockito.mock(HttpClientBuilder.class);
-		CloseableHttpClient client = mock(CloseableHttpClient.class);
-		ClientConnectionManager connectionManager = mock(ClientConnectionManager.class);
-		CloseableHttpResponse resp = mock(CloseableHttpResponse.class);
-		HttpUriRequest req = mock(HttpUriRequest.class);
-		StatusLine statusLine = mock(StatusLine.class);
-		BuildData action = mock(BuildData.class);
-		Revision revision = mock(Revision.class);
-		Build lastBuild = mock(Build.class);
-		List<BuildData> actions = Collections.singletonList(action);
+        buildListener = mock(BuildListener.class);
+        jenkins = mock(Jenkins.class);
+        build = mock(AbstractBuild.class);
+        AbstractProject project = mock(AbstractProject.class);
+        EnvVars environment = mock(EnvVars.class);
+        PrintStream logger = System.out;
+        Secret secret = mock(Secret.class);
+        httpClientBuilder = PowerMockito.mock(HttpClientBuilder.class);
+        CloseableHttpClient client = mock(CloseableHttpClient.class);
+        ClientConnectionManager connectionManager = mock(ClientConnectionManager.class);
+        CloseableHttpResponse resp = mock(CloseableHttpResponse.class);
+        HttpUriRequest req = mock(HttpUriRequest.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        BuildData action = mock(BuildData.class);
+        Revision revision = mock(Revision.class);
+        Build lastBuild = mock(Build.class);
+        List<BuildData> actions = Collections.singletonList(action);
 
-		when(Jenkins.getInstance()).thenReturn(jenkins);
-		when(jenkins.getRootUrl()).thenReturn("http://localhost/");
-		when(build.getEnvironment(buildListener)).thenReturn(environment);
-		when(action.getLastBuiltRevision()).thenReturn(revision);
-		when(revision.getSha1String()).thenReturn(sha1);
-		when(build.getProject()).thenReturn(project);
-                when(build.getFullDisplayName()).thenReturn("foo");
-		when(build.getUrl()).thenReturn("foo");
-		when(build.getActions(BuildData.class)).thenReturn(actions);
-		when(environment.expand(anyString())).thenReturn(sha1);
-		when(buildListener.getLogger()).thenReturn(logger);
-		when(Secret.fromString("tiger")).thenReturn(secret);
-		when(Secret.toString(secret)).thenReturn("tiger");
-		when(secret.getPlainText()).thenReturn("tiger");
-		when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
-		when(httpClientBuilder.build()).thenReturn(client);
-		when(client.getConnectionManager()).thenReturn(connectionManager);
-		when(client.execute((HttpUriRequest)anyObject())).thenReturn(resp);
-		when(resp.getStatusLine()).thenReturn(statusLine);
-		when(statusLine.getStatusCode()).thenReturn(204);
-		action.lastBuild = lastBuild;
-		when(lastBuild.getMarked()).thenReturn(revision);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(jenkins.getRootUrl()).thenReturn("http://localhost/");
+        when(build.getEnvironment(buildListener)).thenReturn(environment);
+        when(action.getLastBuiltRevision()).thenReturn(revision);
+        when(revision.getSha1String()).thenReturn(sha1);
+        when(build.getProject()).thenReturn(project);
+        when(build.getFullDisplayName()).thenReturn("foo");
+        when(build.getUrl()).thenReturn("foo");
+        when(build.getActions(BuildData.class)).thenReturn(actions);
+        when(environment.expand(anyString())).thenReturn(sha1);
+        when(buildListener.getLogger()).thenReturn(logger);
+        when(Secret.fromString("tiger")).thenReturn(secret);
+        when(Secret.toString(secret)).thenReturn("tiger");
+        when(secret.getPlainText()).thenReturn("tiger");
+        when(HttpClientBuilder.create()).thenReturn(httpClientBuilder);
+        when(httpClientBuilder.build()).thenReturn(client);
+        when(client.getConnectionManager()).thenReturn(connectionManager);
+        when(client.execute((HttpUriRequest) anyObject())).thenReturn(resp);
+        when(resp.getStatusLine()).thenReturn(statusLine);
+        when(statusLine.getStatusCode()).thenReturn(204);
+        action.lastBuild = lastBuild;
+        when(lastBuild.getMarked()).thenReturn(revision);
 
-		sn = buildStashNotifier("http://localhost");
-	}
+        sn = buildStashNotifier();
+    }
 
-	@Test
-	public void test_prebuild_normal() {
-		assertTrue(sn.prebuild(build, buildListener));
-	}
+    @Test
+    public void test_prebuild_normal() {
+        assertTrue(sn.prebuild(build, buildListener));
+    }
 
-	@Test
-	public void test_prebuild_null_revision() {
-		when(build.getActions(BuildData.class)).thenReturn(Collections.singletonList(mock(BuildData.class)));
-		assertTrue(sn.prebuild(build, buildListener));
-	}
+    @Test
+    public void test_prebuild_null_revision() {
+        when(build.getActions(BuildData.class)).thenReturn(Collections.singletonList(mock(BuildData.class)));
+        assertTrue(sn.prebuild(build, buildListener));
+    }
 
     @Test
     public void test_build_http_client_with_proxy() throws Exception {
@@ -186,7 +199,16 @@ public class StashNotifierTest
     @Test
     public void test_build_http_client_https() throws Exception {
         //given
-        sn = PowerMockito.spy(buildStashNotifier("https://localhost"));
+        sn = spy(new StashNotifier(
+                "https://localhost",
+                "scot",
+                true,
+                null,
+                true,
+                null,
+                false,
+                false));
+
         doReturn(new ArrayList<Credentials>()).when(sn).lookupCredentials(
                 Mockito.<Class>anyObject(),
                 Mockito.<Item>anyObject(),
@@ -200,5 +222,292 @@ public class StashNotifierTest
         //then
         verify(httpClientBuilder).setSSLSocketFactory(any(SSLConnectionSocketFactory.class));
         verify(httpClientBuilder).setConnectionManager(any(HttpClientConnectionManager.class));
+    }
+
+
+    private void test_perform(Result result, PrintStream logger, NotificationResult notificationResult, List<String> hashes) throws Exception {
+        //given
+        when(buildListener.getLogger()).thenReturn(logger);
+        when(build.getResult()).thenReturn(result);
+        Launcher launcher = mock(Launcher.class);
+        sn = spy(sn);
+        doReturn(hashes).when(sn).lookupCommitSha1s(eq(build), eq(buildListener));
+        doReturn(notificationResult).when(sn).notifyStash(
+                any(PrintStream.class),
+                any(AbstractBuild.class),
+                eq(sha1),
+                eq(buildListener),
+                any(StashBuildState.class)
+        );
+
+        //when
+        boolean perform = sn.perform(build, launcher, buildListener);
+
+        //then
+        assertThat(perform, is(true));
+    }
+
+    @Test
+    public void test_perform_success() throws Exception {
+        //given
+        ArrayList<String> hashes = new ArrayList<String>();
+        hashes.add(sha1);
+        PrintStream logger = mock(PrintStream.class);
+
+        //when
+        test_perform(Result.SUCCESS, logger, new NotificationResult(true, ""), hashes);
+
+        //then
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(logger).println(messageCaptor.capture());
+        assertThat(messageCaptor.getValue(), is(containsString("Notified Stash for commit with id")));
+    }
+
+
+    @Test
+    public void test_perform_failure() throws Exception {
+        //given
+        ArrayList<String> hashes = new ArrayList<String>();
+        hashes.add(sha1);
+        PrintStream logger = mock(PrintStream.class);
+
+        //when
+        test_perform(Result.FAILURE, logger, new NotificationResult(false, ""), hashes);
+
+        //then
+        ArgumentCaptor<String> messageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(logger).println(messageCaptor.capture());
+        assertThat(messageCaptor.getValue(), is(containsString("Failed to notify Stash for commit")));
+    }
+
+    @Test
+    public void test_perform_empty_hash() throws Exception {
+        //given
+        PrintStream logger = mock(PrintStream.class);
+        when(buildListener.getLogger()).thenReturn(logger);
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+        sn = spy(sn);
+        doReturn(new ArrayList<String>()).when(sn).lookupCommitSha1s(eq(build), eq(buildListener));
+
+        //when
+        boolean perform = sn.perform(build, mock(Launcher.class), buildListener);
+
+        //then
+        assertThat(perform, is(true));
+        verify(sn, never()).notifyStash(
+                any(PrintStream.class),
+                any(AbstractBuild.class),
+                anyString(),
+                eq(buildListener),
+                any(StashBuildState.class)
+        );
+        verify(logger).println("found no commit info");
+    }
+
+    @Test
+    public void lookupCommitSha1s() throws InterruptedException, MacroEvaluationException, IOException {
+        PowerMockito.mockStatic(TokenMacro.class);
+        PowerMockito.when(TokenMacro.expandAll(build, buildListener, sha1)).thenReturn(sha1);
+        sn = new StashNotifier(
+                "https://localhost",
+                "scot",
+                true,
+                sha1,
+                true,
+                null,
+                false,
+                false);
+
+        Collection<String> hashes = sn.lookupCommitSha1s(build, buildListener);
+
+        assertThat(hashes.size(), is(1));
+        assertThat(hashes.iterator().next(), is(sha1));
+    }
+
+
+    public void lookupCommitSha1s_Exception(Exception e) throws InterruptedException, MacroEvaluationException, IOException {
+        //given
+        PrintStream logger = mock(PrintStream.class);
+        when(buildListener.getLogger()).thenReturn(logger);
+        PowerMockito.mockStatic(TokenMacro.class);
+        PowerMockito.when(TokenMacro.expandAll(build, buildListener, sha1)).thenThrow(e);
+        sn = new StashNotifier(
+                "http://localhost",
+                "scot",
+                true,
+                sha1,
+                true,
+                null,
+                false,
+                false);
+
+        //when
+        Collection<String> hashes = sn.lookupCommitSha1s(build, buildListener);
+
+        //then
+        assertThat(hashes.isEmpty(), is(true));
+        verify(logger).println("Unable to expand commit SHA value");
+    }
+
+    @Test
+    public void test_lookupCommitSha1s_IOException() throws InterruptedException, MacroEvaluationException, IOException {
+        lookupCommitSha1s_Exception(new IOException("BOOM"));
+    }
+
+    @Test
+    public void test_lookupCommitSha1s_InterruptedException() throws InterruptedException, MacroEvaluationException, IOException {
+        lookupCommitSha1s_Exception(new InterruptedException("BOOM"));
+    }
+
+    @Test
+    public void test_lookupCommitSha1s_MacroEvaluationException() throws InterruptedException, MacroEvaluationException, IOException {
+        lookupCommitSha1s_Exception(new MacroEvaluationException("BOOM"));
+    }
+
+    @Test
+    public void test_getBuildDescription() throws InterruptedException, MacroEvaluationException, IOException {
+        //given
+        AbstractBuild build = mock(AbstractBuild.class);
+        when(build.getDescription()).thenReturn("some description");
+
+        //when
+        String description = sn.getBuildDescription(build, StashBuildState.FAILED);
+
+        //then
+        assertThat(description, is("some description"));
+    }
+
+    private String getBuildDescriptionWhenBuildDescriptionIsNull(StashBuildState buildState) throws InterruptedException, MacroEvaluationException, IOException {
+        return sn.getBuildDescription(mock(AbstractBuild.class), buildState);
+    }
+
+    @Test
+    public void test_getBuildDescription_state() throws InterruptedException, MacroEvaluationException, IOException {
+        assertThat(getBuildDescriptionWhenBuildDescriptionIsNull(StashBuildState.SUCCESSFUL), is("built by Jenkins @ http://localhost/"));
+        assertThat(getBuildDescriptionWhenBuildDescriptionIsNull(StashBuildState.FAILED), is("built by Jenkins @ http://localhost/"));
+        assertThat(getBuildDescriptionWhenBuildDescriptionIsNull(StashBuildState.INPROGRESS), is("building on Jenkins @ http://localhost/"));
+    }
+
+    @Test
+    public void test_createRequest() {
+        //given
+        StashNotifier sn = spy(this.sn);
+        ArrayList<Credentials> credentialList = new ArrayList<Credentials>();
+        UsernamePasswordCredentialsImpl credential = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "", "", "admin", "tiger");
+        credentialList.add(credential);
+        doReturn(credentialList).when(sn).lookupCredentials(
+                Mockito.<Class>anyObject(),
+                Mockito.<Item>anyObject(),
+                Mockito.<Authentication>anyObject(),
+                Mockito.<ArrayList<DomainRequirement>>anyObject());
+        PowerMockito.mockStatic(CredentialsMatchers.class);
+        when(CredentialsMatchers.firstOrNull(anyCollection(), any(CredentialsMatcher.class))).thenReturn(credential);
+
+        //when
+        HttpPost request = sn.createRequest(mock(HttpEntity.class), mock(Item.class), sha1);
+
+        //then
+        assertThat(request, is(not(nullValue())));
+        assertThat(request.getHeaders("Authorization"), is(not(nullValue())));
+    }
+
+    @Test
+    public void test_getBuildKey() throws InterruptedException, MacroEvaluationException, IOException {
+        //given
+        String key = "someKey";
+        PrintStream logger = mock(PrintStream.class);
+        when(buildListener.getLogger()).thenReturn(logger);
+        PowerMockito.mockStatic(TokenMacro.class);
+        PowerMockito.when(TokenMacro.expandAll(build, buildListener, key)).thenReturn(key);
+
+        sn = new StashNotifier(
+                "",
+                "scot",
+                true,
+                null,
+                true,
+                key,
+                true,
+                false);
+
+        String buildKey = sn.getBuildKey(build, buildListener);
+        assertThat(buildKey, is(key));
+    }
+
+
+    public void getBuildKey_Exception(Exception e) throws InterruptedException, MacroEvaluationException, IOException {
+        //given
+        String key = "someKey";
+        PrintStream logger = mock(PrintStream.class);
+        when(buildListener.getLogger()).thenReturn(logger);
+        PowerMockito.mockStatic(TokenMacro.class);
+        PowerMockito.when(TokenMacro.expandAll(build, buildListener, key)).thenThrow(e);
+
+        sn = new StashNotifier(
+                "",
+                "scot",
+                true,
+                null,
+                true,
+                key,
+                true,
+                false);
+
+        //when
+        String buildKey = sn.getBuildKey(build, buildListener);
+
+        //then
+        assertThat(buildKey, is("null-0-http:\\/\\/localhost\\/"));
+        verify(logger).println("Cannot expand build key from parameter. Processing with default build key");
+    }
+
+    @Test
+    public void test_getBuildKey_IOException() throws InterruptedException, MacroEvaluationException, IOException {
+        getBuildKey_Exception(new IOException("BOOM"));
+    }
+
+    @Test
+    public void test_getBuildKey_InterruptedException() throws InterruptedException, MacroEvaluationException, IOException {
+        getBuildKey_Exception(new InterruptedException("BOOM"));
+    }
+
+    @Test
+    public void test_getBuildKey_MacroEvaluationException() throws InterruptedException, MacroEvaluationException, IOException {
+        getBuildKey_Exception(new MacroEvaluationException("BOOM"));
+    }
+
+    private NotificationResult notifyStash(int statusCode) throws Exception {
+        sn = spy(this.sn);
+        PrintStream logger = mock(PrintStream.class);
+        when(buildListener.getLogger()).thenReturn(logger);
+        doReturn("someKey1").when(sn).getBuildKey(eq(build), eq(buildListener));
+        HttpPost httpPost = mock(HttpPost.class);
+        doReturn(httpPost).when(sn).createRequest(any(HttpEntity.class), any(Item.class), anyString());
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse resp = mock(HttpResponse.class);
+        StatusLine sl = mock(StatusLine.class);
+        when(sl.getStatusCode()).thenReturn(statusCode);
+        when(resp.getStatusLine()).thenReturn(sl);
+        when(resp.getEntity()).thenReturn(new StringEntity(""));
+        when(httpClient.execute(eq(httpPost))).thenReturn(resp);
+        doReturn(httpClient).when(sn).getHttpClient(any(PrintStream.class), any(AbstractBuild.class));
+
+        ClientConnectionManager manager = mock(ClientConnectionManager.class);
+        doReturn(manager).when(httpClient).getConnectionManager();
+
+
+        return sn.notifyStash(logger, build, sha1, buildListener, StashBuildState.FAILED);
+    }
+
+    @Test
+    public void notifyStash_success() throws Exception {
+        NotificationResult notificationResult = notifyStash(204);
+        assertThat(notificationResult.indicatesSuccess, is(true));
+    }
+
+    @Test
+    public void notifyStash_fail() throws Exception {
+        NotificationResult notificationResult = notifyStash(400);
+        assertThat(notificationResult.indicatesSuccess, is(false));
     }
 }


### PR DESCRIPTION
This pull request is focused on stashnotifier-plugin. Code coverage is measured using cobertura. This pull request increases code coverage of the whole project by 86%.

Metric | Before | After
------ | ------ | -----
Coverage % | 37% | 86%
Lines Covered | 104 | 382
Total Lines | 104 | 452

Please let me know if you have any questions. 

Vladislav Medvedev
DevFactory - Code Quality Team