### PR TITLE
Adding a timeout for the url request so the plugin will not hang forever

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -48,6 +48,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.auth.*;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.HttpClientConnectionManager;
@@ -389,6 +390,9 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
         URL url = new URL(stashServer);
         HttpClientBuilder builder = HttpClientBuilder.create();
+        RequestConfig.Builder requestBuilder = RequestConfig.custom();
+        requestBuilder = requestBuilder.setSocketTimeout(60000);
+        builder.setDefaultRequestConfig(requestBuilder.build());
         if (url.getProtocol().equals("https")
                 && (ignoreUnverifiedSSL || certificateCredentials instanceof CertificateCredentials)) {
 			// add unsafe trust manager to avoid thrown


### PR DESCRIPTION
Adding a timeout for the url request so the plugin will not hang forever if the Stash server does not respond

This solves JENKINS-36346 according to my tests...
