### PR TITLE
Support not built state

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -202,7 +202,7 @@ public class StashNotifier extends Notifier {
 			BuildListener listener) {
 
 		if ((build.getResult() == null)
-				|| (!build.getResult().equals(Result.SUCCESS))) {
+				|| (!build.getResult().equals(Result.FAILURE))) {
 			return processJenkinsEvent(
 					build, listener, StashBuildState.FAILED);
 		} else

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -205,10 +205,8 @@ public class StashNotifier extends Notifier {
 				|| (!build.getResult().equals(Result.SUCCESS))) {
 			return processJenkinsEvent(
 					build, listener, StashBuildState.FAILED);
-		} else {
-			return processJenkinsEvent(
-					build, listener, StashBuildState.SUCCESSFUL);
-		}
+		} else
+			return build.getResult().equals(Result.NOT_BUILT) || processJenkinsEvent(build, listener, StashBuildState.SUCCESSFUL);
 	}
 
 	/**

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -202,7 +202,7 @@ public class StashNotifier extends Notifier {
 			BuildListener listener) {
 
 		if ((build.getResult() == null)
-				|| (!build.getResult().equals(Result.FAILURE))) {
+				|| (build.getResult().equals(Result.FAILURE))) {
 			return processJenkinsEvent(
 					build, listener, StashBuildState.FAILED);
 		} else


### PR DESCRIPTION
We don't want to indicate failure for jobs where the NOT BUILT status is encountered. Also, there may be extensions that make use of this result state. This extension is one example that I know of which makes use of the NOT BUILT state https://wiki.jenkins-ci.org/display/JENKINS/Pathignore+Plugin