### PR TITLE
Implementation of notification override mechanism

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -64,6 +64,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.ProxyAuthenticationStrategy;
 import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.http.util.EntityUtils;
+import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.stapler.AncestorInPath;
@@ -100,6 +101,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
 	public static final int MAX_FIELD_LENGTH = 255;
 	public static final int MAX_URL_FIELD_LENGTH = 450;
+	public static final String DEFAULT_DESCRIPTION = "Build ${BUILD_DISPLAY_NAME} on ${NODE_NAME}: ${BUILD_RESULT}";
 
 	// attributes --------------------------------------------------------------
 
@@ -127,6 +129,12 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 	/** whether to send INPROGRESS notification at the build start */
 	private final boolean disableInprogressNotification;
 
+	/** specify the notification description field from config */
+	private String description;
+
+	/** if true, use description set on the build job instead of the description set in plugin config */
+	private final boolean useJobDescription;
+
 	private final Jenkins jenkins = Jenkins.getInstance();
 
 	private JenkinsLocationConfiguration globalConfig = new JenkinsLocationConfiguration();
@@ -146,7 +154,9 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 			boolean includeBuildNumberInKey,
 			String projectKey,
 			boolean prependParentProjectKey,
-			boolean disableInprogressNotification
+			boolean disableInprogressNotification,
+			String description,
+			boolean useJobDescription
 	) {
 
 
@@ -161,6 +171,18 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 		this.projectKey = projectKey;
 		this.prependParentProjectKey = prependParentProjectKey;
 		this.disableInprogressNotification = disableInprogressNotification;
+		if (StringUtils.isNotBlank(description)) {
+			this.description = description;
+		}
+		this.useJobDescription = useJobDescription;
+	}
+
+	public boolean isUseJobDescription() {
+		return useJobDescription;
+	}
+
+	public String getDescription() {
+		return description;
 	}
 
 	public boolean isDisableInprogressNotification() {
@@ -456,7 +478,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 					.loadTrustMaterial(null, easyStrategy);
 		}
 		return customContext.useTLS().build();
-}
+	}
 
 	private void configureProxy(HttpClientBuilder builder, URL url) {
 		if (jenkins == null) {
@@ -518,6 +540,8 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 		private String projectKey;
 		private boolean prependParentProjectKey;
 		private boolean disableInprogressNotification;
+		private String description;
+		private boolean useJobDescription;
 
         public DescriptorImpl() {
             this(true);
@@ -562,6 +586,14 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 	            return stashRootUrl;
         	}
         }
+
+        public boolean isUseJobDescription() {
+        	return useJobDescription;
+		}
+
+        public String getDescription() {
+        	return description;
+		}
 
 		public boolean isDisableInprogressNotification() {
 			return disableInprogressNotification;
@@ -656,8 +688,34 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
 			disableInprogressNotification = formData.getBoolean("disableInprogressNotification");
 
+			if (formData.has("description") && StringUtils.isNotBlank(formData.getString("description"))) {
+				description = formData.getString("description");
+			}
+
+			if (formData.has("useJobDescription")) {
+				useJobDescription = formData.getBoolean("useJobDescription");
+			}
+
 			save();
 			return super.configure(req,formData);
+		}
+	}
+
+	@Extension
+	public static class BuildResultTokenMacro extends DataBoundTokenMacro {
+
+		@Override
+		public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName) throws MacroEvaluationException, IOException, InterruptedException {
+			Result result = context.getResult();
+			if (result == null) {
+				return StashBuildState.INPROGRESS.toString();
+			}
+			return result.toString();
+		}
+
+		@Override
+		public boolean acceptsMacroName(String macroName) {
+			return macroName.equals("BUILD_RESULT");
 		}
 	}
 
@@ -835,7 +893,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
                 replaceAll("\\\\u00BB", "\\/");
         json.put("name", abbreviate(fullName, MAX_FIELD_LENGTH));
 
-		json.put("description", abbreviate(getBuildDescription(run, state), MAX_FIELD_LENGTH));
+		json.put("description", abbreviate(getBuildDescription(run, listener, state), MAX_FIELD_LENGTH));
 		json.put("url", abbreviate(getRootUrl().concat(run.getUrl()), MAX_URL_FIELD_LENGTH));
 
         return new StringEntity(json.toString(), "UTF-8");
@@ -921,31 +979,65 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 		return StringEscapeUtils.escapeJavaScript(key.toString());
 	}
 
+	private String getDefaultBuildDescription(final Run<?, ?> run, final StashBuildState state) {
+		if (StringUtils.isNotBlank(run.getDescription())) {
+			return run.getDescription();
+		} else {
+			switch (state) {
+				case INPROGRESS:
+					return "building on Jenkins @ "
+							+ getRootUrl();
+				default:
+					return DEFAULT_DESCRIPTION;
+			}
+		}
+	}
+
 	/**
 	 * Returns the description of the run used for the Stash notification.
 	 * Uses the run description provided by the Jenkins job, if available.
 	 *
-	 * @param run		the run to be described
-	 * @param state		the state of the run
-	 * @return			the description of the run
+	 * @param run        the run to be described
+	 * @param listener
+	 *@param state        the state of the run  @return			the description of the run
 	 */
 	protected String getBuildDescription(
 			final Run<?, ?> run,
+			final TaskListener listener,
 			final StashBuildState state) {
 
-		if (run.getDescription() != null
-				&& run.getDescription().trim().length() > 0) {
-
-			return run.getDescription();
+		String description = null;
+		if (useJobDescription) {
+			if (StringUtils.isNotBlank(run.getDescription())) {
+				description = run.getDescription();
+			}
 		} else {
-			switch (state) {
-			case INPROGRESS:
-	            return "building on Jenkins @ "
-					+ getRootUrl();
-			default:
-	            return "built by Jenkins @ "
-	            	+ getRootUrl();
+			if (StringUtils.isNotBlank(getDescription())) {
+				description = getDescription();
 			}
 		}
+
+		if (StringUtils.isBlank(description)) {
+			description = DEFAULT_DESCRIPTION;
+		}
+
+		if (run instanceof AbstractBuild<?, ?>) {
+			PrintStream logger = listener.getLogger();
+			try {
+				description = TokenMacro.expandAll((AbstractBuild<?, ?>) run, listener, description);
+			} catch (Exception e) {
+				logger.println("Cannot expand build description from parameter. Processing with default build description");
+				e.printStackTrace(logger);
+				switch (state) {
+					case INPROGRESS:
+						description = "building on Jenkins @ " + getRootUrl();
+						break;
+					default:
+						description = "built by Jenkins @ " + getRootUrl();
+				}
+			}
+		}
+
+		return description;
 	}
 }

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
@@ -31,5 +31,11 @@
   <f:entry title="Disable INPROGRESS notification" field="disableInprogressNotification">
     <f:checkbox/>
   </f:entry>
+  <f:entry title="Build description" field="description">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="Use description from the Job as 'build description'" field="useJobDescription">
+    <f:checkbox default="true"/>
+  </f:entry>
  </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
@@ -28,5 +28,15 @@
                help="${rootURL}/plugin/stashNotifier/help-globalConfig-disableInprogressNotification.html">
           <f:checkbox default="true"/>
       </f:entry>
+      <f:entry title="Build description"
+               field="description"
+               help="${rootURL}/plugin/stashNotifier/help-globalConfig-description.html">
+          <f:textbox />
+      </f:entry>
+      <f:entry title="Use description from the Job as 'build description'"
+               field="useJobDescription"
+               help="${rootURL}/plugin/stashNotifier/help-globalConfig-useJobDescription.html">
+          <f:checkbox default="true"/>
+      </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-description.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-description.html
@@ -1,0 +1,12 @@
+<div>
+  <p>
+    A <tt>TokenMacro</tt> compatible string to use as the notification sent to Stash. Activated when "use job description" parameter is unchecked.
+    As part of <tt>TokenMacro</tt> support, this plugin defines a new macro, <tt>${BUILD_RESULT}</tt>, that resolves to
+    the current build's result (i.e. <tt>SUCCESSFUL</tt>, <tt>FAILED</tt>, etc).<br>
+    If left blank, default description used is:
+  <ul>
+    <li><tt>Build ${BUILD_DISPLAY_NAME} on ${NODE_NAME}: ${BUILD_RESULT}</tt></li>
+  </ul>
+  which gets rendered as <tt>Build #123 on master: SUCCESSFUL</tt>
+  </p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-useJobDescription.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-useJobDescription.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Check this if you want to use the value of the job's description field as the notification sent to Stash.
+  </p>
+</div>

--- a/src/main/webapp/help-globalConfig-description.html
+++ b/src/main/webapp/help-globalConfig-description.html
@@ -1,0 +1,12 @@
+<div>
+  <p>
+    A <tt>TokenMacro</tt> compatible string to use as the notification sent to Stash. Activated when "use job description" parameter is unchecked.
+    As part of <tt>TokenMacro</tt> support, this plugin defines a new macro, <tt>${BUILD_RESULT}</tt>, that resolves to
+    the current build's result (i.e. <tt>SUCCESSFUL</tt>, <tt>FAILED</tt>, etc).<br>
+    If left blank, default description used is:
+    <ul>
+      <li><tt>Build ${BUILD_DISPLAY_NAME} on ${NODE_NAME}: ${BUILD_RESULT}</tt></li>
+    </ul>
+    which gets rendered as <tt>Build #123 on master: SUCCESSFUL</tt>
+  </p>
+</div>

--- a/src/main/webapp/help-globalConfig-useJobDescription.html
+++ b/src/main/webapp/help-globalConfig-useJobDescription.html
@@ -1,0 +1,5 @@
+<div>
+  <p>
+    Check this if you want to use the value of the job's description field as the notification sent to Stash.
+  </p>
+</div>


### PR DESCRIPTION
Implementing issue/request #107:

* Added "useJobDescription" boolean field
* Added "description" TokenMacro-compatible field to override notification sent
* Added TokenMacro macro BUILD_RESULT containing Jenkins build result