### PR TITLE
added pipeline compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>1.11</version>
+            <version>2.0</version>
             <type>jar</type>
         </dependency>
     </dependencies>

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -900,12 +900,12 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 		String overriddenKey = (projectKey != null && projectKey.trim().length() > 0) ? projectKey : getDescriptor().getProjectKey();
 		if (overriddenKey != null && overriddenKey.trim().length() > 0) {
 			PrintStream logger = listener.getLogger();
-			if (!(run instanceof AbstractBuild<?, ?>)) {
-				logger.println("Unable to expand build key macro with run of type " + run.getClass().getName());
-				key.append(getDefaultBuildKey(run));
-			} else {
 				try {
-					key.append(TokenMacro.expandAll((AbstractBuild<?, ?>) run, listener, projectKey));
+					if (!(run instanceof AbstractBuild<?, ?>)) {
+						key.append(TokenMacro.expandAll(run, new FilePath(run.getRootDir()), listener, projectKey));
+					} else {
+						key.append(TokenMacro.expandAll((AbstractBuild<?, ?>) run, listener, projectKey));
+					}
 				} catch (IOException ioe) {
 					logger.println("Cannot expand build key from parameter. Processing with default build key");
 					ioe.printStackTrace(logger);
@@ -918,7 +918,6 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 					logger.println("Cannot expand build key from parameter. Processing with default build key");
 					mee.printStackTrace(logger);
 					key.append(getDefaultBuildKey(run));
-				}
 			}
 		} else {
 			key.append(getDefaultBuildKey(run));


### PR DESCRIPTION
Plugin token-macro add pipeline compatibility as of version 2.0.  getBuildKey was failing with `Unable to expand build key macro with run of type org.jenkinsci.plugins.workflow.job.WorkflowRun` when notifying in pipeline