### PR TITLE
Use DisplayURLProvider to support Blue Ocean URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>display-url-api</artifactId>
+            <version>1.1.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>19.0</version>

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -65,6 +65,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.ProxyAuthenticationStrategy;
 import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.http.util.EntityUtils;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.stapler.AncestorInPath;
@@ -842,7 +843,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         json.put("name", abbreviate(fullName, MAX_FIELD_LENGTH));
 
 		json.put("description", abbreviate(getBuildDescription(run, state), MAX_FIELD_LENGTH));
-		json.put("url", abbreviate(getRootUrl().concat(run.getUrl()), MAX_URL_FIELD_LENGTH));
+		json.put("url", abbreviate(DisplayURLProvider.get().getRunURL(run), MAX_URL_FIELD_LENGTH));
 
         return new StringEntity(json.toString(), "UTF-8");
 	}


### PR DESCRIPTION
This PR updates the build link to the new URL compatible with [Blue Ocean](https://jenkins.io/projects/blueocean/). The link will be redirected to Blue Ocean's page if available.

![image](https://cloud.githubusercontent.com/assets/774048/24187895/778e63f4-0f22-11e7-809b-4f6079aee68c.png)

- [Display URL API](https://plugins.jenkins.io/display-url-api)
- [Implement a DisplayURLProvider for Blue Ocean - Jenkins JIRA](https://issues.jenkins-ci.org/browse/JENKINS-37878)