### PR TITLE
Ability to ignore or succeed by config settings

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
@@ -31,5 +31,11 @@
   <f:entry title="Disable INPROGRESS notification" field="disableInprogressNotification">
     <f:checkbox/>
   </f:entry>
+  <f:entry title="Disable ABORTED builds notification" field="disableAbortAsFailures">
+    <f:checkbox/>
+  </f:entry>
+  <f:entry title="Consider UNSTABLE builds as SUCCESS notification" field="considerUnstableAsSuccess">
+    <f:checkbox/>
+  </f:entry>
  </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
@@ -28,5 +28,15 @@
                help="${rootURL}/plugin/stashNotifier/help-globalConfig-disableInprogressNotification.html">
           <f:checkbox default="true"/>
       </f:entry>
+      <f:entry title="Disable ABORTED builds notification"
+               field="disableAbortAsFailures"
+               help="${rootURL}/plugin/stashNotifier/help-globalConfig-disableAbortAsFailures.html">
+          <f:checkbox default="false"/>
+      </f:entry>
+      <f:entry title="Consider UNSTABLE builds as SUCCESS notification"
+               field="considerUnstableAsSuccess"
+               help="${rootURL}/plugin/stashNotifier/help-globalConfig-considerUnstableAsSuccess.html">
+          <f:checkbox default="false"/>
+      </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/webapp/help-globalConfig-considerUnstableAsSuccess.html
+++ b/src/main/webapp/help-globalConfig-considerUnstableAsSuccess.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Consider unstable builds as success, besides the test errors.</p>
+</div>

--- a/src/main/webapp/help-globalConfig-disableAbortAsFailures.html
+++ b/src/main/webapp/help-globalConfig-disableAbortAsFailures.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Disable sending notifications when build has been aborted</p>
+</div>

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
@@ -67,6 +67,8 @@ public class StashNotifierTest
 				true,
 				null,
 				false,
+				false,
+				false,
 				false);
 	}
 


### PR DESCRIPTION
Introduce two new configuration settings to allow to control the
Stash notification in case of build aborted or unstable:

- disableAbortAsFailure: do not notify anything if build is aborted
- considerUnstableAsSuccess: when build is finished with some failures,
  consider the stash notification as a success