### PR TITLE
Ability to ignore or succeed by config settings

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
@@ -31,5 +31,8 @@
   <f:entry title="Disable INPROGRESS notification" field="disableInprogressNotification">
     <f:checkbox/>
   </f:entry>
+  <f:entry title="Consider UNSTABLE builds as SUCCESS notification" field="considerUnstableAsSuccess">
+    <f:checkbox/>
+  </f:entry>
  </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
@@ -28,5 +28,10 @@
                help="${rootURL}/plugin/stashNotifier/help-globalConfig-disableInprogressNotification.html">
           <f:checkbox default="true"/>
       </f:entry>
+      <f:entry title="Consider UNSTABLE builds as SUCCESS notification"
+               field="considerUnstableAsSuccess"
+               help="${rootURL}/plugin/stashNotifier/help-globalConfig-considerUnstableAsSuccess.html">
+          <f:checkbox default="false"/>
+      </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/webapp/help-globalConfig-considerUnstableAsSuccess.html
+++ b/src/main/webapp/help-globalConfig-considerUnstableAsSuccess.html
@@ -1,0 +1,3 @@
+<div>
+    <p>Consider unstable builds as success, besides the test errors.</p>
+</div>


### PR DESCRIPTION
Introduce two new configuration settings to allow to control the
Stash notification in case of build aborted or unstable:

- disableAbortAsFailure: do not notify anything if build is aborted
- considerUnstableAsSuccess: when build is finished with some failures,
  consider the stash notification as a success