### PR TITLE
Use buildPlugin() for building/testing in ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,1 @@
-node('maven') {
-   stage('Preparation') {
-      checkout scm
-   }
-   stage('Build') {
-      sh "mvn -Dmaven.test.failure.ignore clean package"
-   }
-   stage('Results') {
-      archive 'target/*.jar'
-      archive 'target/*.hpi'
-   }
-}
+buildPipeline()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPipeline()
+buildPlugin()


### PR DESCRIPTION
This plugin can take advantage of the project's CI infrastructure at ci.jenkins.io

This is using just the Shard Library method "buildPlugin()" (see: https://github.com/jenkins-infra/pipeline-library#buildplugin) which does the appropriate thing for most plugins using Maven/Gradle :smile: