### PR TITLE
Extend "Ability to ignore or succeed by config settings"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,7 @@ def notifyStash(String state) {
           commitSha1: "$commit",            // jenkins parameter that resolves to commit's hash
           credentialsId: '00000000-1111-2222-3333-123456789abc',
           disableInprogressNotification: false,
+          considerUnstableAsSuccess: true,
           ignoreUnverifiedSSLPeer: true,
           includeBuildNumberInKey: false,
           prependParentProjectKey: false,

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -173,6 +173,10 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 		return disableInprogressNotification;
 	}
 
+	public boolean isConsiderUnstableAsSuccess() {
+		return considerUnstableAsSuccess;
+	}
+
 	public String getCredentialsId() {
 		return credentialsId;
 	}
@@ -535,6 +539,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 		private String projectKey;
 		private boolean prependParentProjectKey;
 		private boolean disableInprogressNotification;
+		private boolean considerUnstableAsSuccess;
 
         public DescriptorImpl() {
             this(true);
@@ -582,6 +587,10 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
 		public boolean isDisableInprogressNotification() {
 			return disableInprogressNotification;
+		}
+
+		public boolean isConsiderUnstableAsSuccess() {
+			return considerUnstableAsSuccess;
 		}
 
 		public String getCredentialsId() {
@@ -674,6 +683,8 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             prependParentProjectKey = formData.getBoolean("prependParentProjectKey");
 
 			disableInprogressNotification = formData.getBoolean("disableInprogressNotification");
+
+			considerUnstableAsSuccess = formData.getBoolean("considerUnstableAsSuccess");
 
 			save();
 			return super.configure(req,formData);

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-considerUnstableAsSuccess.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-considerUnstableAsSuccess.html
@@ -1,0 +1,3 @@
+<div>
+    Consider unstable builds as success, besides the test errors.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
@@ -62,6 +62,7 @@ public class DescriptorImplTest {
         json.put("includeBuildNumberInKey", "true");
         json.put("prependParentProjectKey", "true");
         json.put("disableInprogressNotification", "true");
+        json.put("considerUnstableAsSuccess", "true");
 
         desc = spy(new StashNotifier.DescriptorImpl(false));
     }
@@ -80,6 +81,7 @@ public class DescriptorImplTest {
         assertThat(desc.getProjectKey(), is("someProjectKey"));
         assertThat(desc.getDisplayName(), is("Notify Stash Instance"));
         assertThat(desc.isDisableInprogressNotification(), is(true));
+        assertThat(desc.isConsiderUnstableAsSuccess(), is(true));
         assertThat(desc.isIgnoreUnverifiedSsl(), is(true));
         assertThat(desc.isIncludeBuildNumberInKey(), is(true));
         assertThat(desc.isPrependParentProjectKey(), is(true));

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
@@ -67,7 +67,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Secret.class, Jenkins.class, HttpClientBuilder.class, TokenMacro.class, CredentialsMatchers.class, com.cloudbees.plugins.credentials.CredentialsProvider.class})
+@PrepareForTest({Secret.class, Jenkins.class, HttpClientBuilder.class, TokenMacro.class, CredentialsMatchers.class, com.cloudbees.plugins.credentials.CredentialsProvider.class, AbstractProject.class})
 @PowerMockIgnore("javax.net.ssl.*")
 public class StashNotifierTest
 {
@@ -117,7 +117,11 @@ public class StashNotifierTest
 		jenkins = mock(Hudson.class);
 		build = mock(AbstractBuild.class);
 		run = mock(Run.class);
-		AbstractProject project = mock(AbstractProject.class);
+		AbstractProject project = PowerMockito.mock(AbstractProject.class);
+        File file = mock(File.class);
+        when(file.getPath()).thenReturn("/tmp/fake/path");
+        FilePath filePath = new FilePath(file);
+        PowerMockito.when(project.getSomeWorkspace()).thenReturn(filePath);
 		workspace = project.getSomeWorkspace();
 		EnvVars environment = mock(EnvVars.class);
 		PrintStream logger = System.out;


### PR DESCRIPTION
Extended the commit da88dd7ad4d4e5d6f7d730dcf11715a09f895729.

Now will store considerUnstableAsSuccess when set via global config, was not saving values set.
Updated some failing tests.
Updated README.