### PR TITLE
Remove escaping operation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -885,13 +885,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
         json.put("key", abbreviate(getBuildKey(run, listener), MAX_FIELD_LENGTH));
 
-        // This is to replace the odd character Jenkins injects to separate
-        // nested jobs, especially when using the Cloudbees Folders plugin.
-        // These characters cause Stash to throw up.
-        String fullName = StringEscapeUtils.
-                escapeJavaScript(run.getFullDisplayName()).
-                replaceAll("\\\\u00BB", "\\/");
-        json.put("name", abbreviate(fullName, MAX_FIELD_LENGTH));
+        json.put("name", abbreviate(run.getFullDisplayName(), MAX_FIELD_LENGTH));
 
 		json.put("description", abbreviate(getBuildDescription(run, state), MAX_FIELD_LENGTH));
 		json.put("url", abbreviate(DisplayURLProvider.get().getRunURL(run), MAX_URL_FIELD_LENGTH));


### PR DESCRIPTION
I removed JavaScript escaping by reason of later version works without it.
I confirmed with "Atlassian Bitbucket v4.8.1" on-premise sever.
Notifications were done without any error and multibyte letters seem properly in BitBucket server's build status page.