### PR TITLE
Support SHA-1 commit lookup for all runs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -207,7 +207,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
     @Override
 	public boolean prebuild(AbstractBuild<?, ?> build, BuildListener listener) {
-		    return disableInprogressNotification || processJenkinsEvent(build, listener, StashBuildState.INPROGRESS);
+		    return disableInprogressNotification || processJenkinsEvent(build, null, listener, StashBuildState.INPROGRESS);
 	}
 
 	@Override
@@ -215,7 +215,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 			AbstractBuild<?, ?> build,
 			Launcher launcher,
 			BuildListener listener) {
-		return perform(build, listener, disableInprogressNotification);
+		return perform(build, null, listener, disableInprogressNotification);
 	}
 
 	@Override
@@ -223,12 +223,13 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 						@Nonnull FilePath workspace,
 						@Nonnull Launcher launcher,
 						@Nonnull TaskListener listener) throws InterruptedException, IOException {
-		if (!perform(run, listener, false)) {
+		if (!perform(run, workspace, listener, false)) {
 			run.setResult(Result.FAILURE);
 		}
 	}
 
 	private boolean perform(Run<?, ?> run,
+							FilePath workspace,
 							TaskListener listener,
 							boolean disableInProgress) {
 		StashBuildState state;
@@ -255,7 +256,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 			state = StashBuildState.FAILED;
 		}
 
-		return processJenkinsEvent(run, listener, state);
+		return processJenkinsEvent(run, null, listener, state);
 	}
 
 	/**
@@ -278,6 +279,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 	 * initiates the Stash notification.
 	 *
 	 * @param run		the run to notify Stash of
+	 * @param workspace	the workspace of a non-AbstractBuild build
 	 * @param listener	the Jenkins build listener
 	 * @param state		the state of the build (in progress, success, failed)
 	 * @return			always true in order not to abort the Job in case of
@@ -285,6 +287,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 	 */
 	private boolean processJenkinsEvent(
 			final Run<?, ?> run,
+			final FilePath workspace,
 			final TaskListener listener,
 			final StashBuildState state) {
 
@@ -298,7 +301,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 			return true;
 		}
 
-		Collection<String> commitSha1s = lookupCommitSha1s(run, listener);
+		Collection<String> commitSha1s = lookupCommitSha1s(run, workspace, listener);
 		for  (String commitSha1 : commitSha1s) {
 			try {
 				NotificationResult result
@@ -333,17 +336,19 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
     protected Collection<String> lookupCommitSha1s(
 			@SuppressWarnings("rawtypes") Run run,
+			FilePath workspace,
 			TaskListener listener) {
 
 		if (commitSha1 != null && commitSha1.trim().length() > 0) {
 			PrintStream logger = listener.getLogger();
-			if (!(run instanceof AbstractBuild)) {
-				logger.println("Unable to expand commit SHA value with " + run.getClass().getName());
-				return Collections.singletonList(commitSha1);
-			}
 
 			try {
-				return Arrays.asList(TokenMacro.expandAll((AbstractBuild) run, listener, commitSha1));
+				if (run instanceof AbstractBuild) {
+					return Arrays.asList(TokenMacro.expandAll((AbstractBuild) run, listener, commitSha1));
+				}
+				else {
+					return Arrays.asList(TokenMacro.expandAll(run, workspace, listener, commitSha1));
+				}
 			} catch (IOException e) {
 				logger.println("Unable to expand commit SHA value");
 				e.printStackTrace(logger);

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
@@ -295,7 +295,7 @@ public class StashNotifierTest
         when(build.getResult()).thenReturn(result);
         Launcher launcher = mock(Launcher.class);
         sn = spy(sn);
-        doReturn(hashes).when(sn).lookupCommitSha1s(eq(build), eq(buildListener));
+        doReturn(hashes).when(sn).lookupCommitSha1s(eq(build), eq((FilePath)null), eq(buildListener));
         doReturn(notificationResult).when(sn).notifyStash(
                 any(PrintStream.class),
                 any(AbstractBuild.class),
@@ -397,7 +397,7 @@ public class StashNotifierTest
         when(buildListener.getLogger()).thenReturn(logger);
         when(build.getResult()).thenReturn(Result.SUCCESS);
         sn = spy(sn);
-        doReturn(new ArrayList<String>()).when(sn).lookupCommitSha1s(eq(build), eq(buildListener));
+        doReturn(new ArrayList<String>()).when(sn).lookupCommitSha1s(eq(build), eq((FilePath)null), eq(buildListener));
 
         //when
         boolean perform = sn.perform(build, mock(Launcher.class), buildListener);
@@ -470,7 +470,7 @@ public class StashNotifierTest
         when(buildListener.getLogger()).thenReturn(logger);
         when(build.getResult()).thenReturn(Result.SUCCESS);
         sn = spy(sn);
-        doReturn(new ArrayList<String>()).when(sn).lookupCommitSha1s(eq(build), eq(buildListener));
+        doReturn(new ArrayList<String>()).when(sn).lookupCommitSha1s(eq(build), eq((FilePath)null), eq(buildListener));
 
         //when
         sn.perform(build, workspace, mock(Launcher.class), buildListener);
@@ -501,7 +501,7 @@ public class StashNotifierTest
                 false,
                 false);
 
-        Collection<String> hashes = sn.lookupCommitSha1s(build, buildListener);
+        Collection<String> hashes = sn.lookupCommitSha1s(build, null, buildListener);
 
         assertThat(hashes.size(), is(1));
         assertThat(hashes.iterator().next(), is(sha1));
@@ -526,7 +526,7 @@ public class StashNotifierTest
                 false);
 
         //when
-        Collection<String> hashes = sn.lookupCommitSha1s(build, buildListener);
+        Collection<String> hashes = sn.lookupCommitSha1s(build, null, buildListener);
 
         //then
         assertThat(hashes.isEmpty(), is(true));


### PR DESCRIPTION
When given an AbstractBuild Run, the lookupCommitSha1s() function had the
information for TokenMacro to expand the SHA-1 commits.  However, if the
Run was a non-AbstractBuild object, there was not enough information for
TokenMacro to perform expansion (at least, with the parameters originally
provided).

Because of this, warnings were displayed by the StashNotifier step on some
of the runs.  Quite often, StashNotifier is one of the last steps of a
build, so the StashNotifier warning was right next to the final message
about a build failure.  And since the two "errors" were right next to each
other in the log, new users looking at the Console Output often came to
the incorrect conclusion that StashNotifier was the cause of the error.

Fortunately, TokenMacro has a second function to expandAll macros, one
that works for non-AbstractBuilds.  It requires an additional parameter,
but we are given a copy of it in the perform() routine: the workspace.  By
passing this parameter down the stack, we can enable token expansion on
all types of Runs.