### PR TITLE
Use DisplayURLProvider for computing the build URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.502</version>
+        <version>1.625.3</version>
     </parent>
 
     <artifactId>stashNotifier</artifactId>
@@ -122,6 +122,11 @@
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-core</artifactId>
             <version>1.502</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>display-url-api</artifactId>
+            <version>0.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -61,6 +61,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.ProxyAuthenticationStrategy;
 import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.http.util.EntityUtils;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.stapler.AncestorInPath;
@@ -744,7 +745,7 @@ public class StashNotifier extends Notifier {
         json.put("name", abbreviate(fullName, MAX_FIELD_LENGTH));
 
 		json.put("description", abbreviate(getBuildDescription(build, state), MAX_FIELD_LENGTH));
-		json.put("url", abbreviate(getRootUrl().concat(build.getUrl()), MAX_URL_FIELD_LENGTH));
+		json.put("url", abbreviate(DisplayURLProvider.get().getRunURL(build), MAX_URL_FIELD_LENGTH));
 
         return new StringEntity(json.toString(), "UTF-8");
 	}


### PR DESCRIPTION
If the Jenkins instance has Blue Ocean installed, we should generate a
URL for the relevant part of the Blue Ocean API.

See [JENKINS-37878](https://issues.jenkins-ci.org/browse/JENKINS-37878).

Also update the minimum Jenkins version to match display-url-api:
https://github.com/jenkinsci/display-url-api-plugin/blob/display-url-api-0.1/pom.xml#L16