### PR TITLE
Add setters to the StashNotifier.DescriptorImpl class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.36</version>
+        <version>3.40</version>
         <relativePath />
     </parent>
     <packaging>hpi</packaging>
@@ -14,14 +14,6 @@
         <jenkins.version>2.60.3</jenkins.version>
         <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
         <java.level>8</java.level>
-        <!-- Jenkins Test Harness version you use to test the plugin. -->
-        <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-        <jenkins-test-harness.version>2.48</jenkins-test-harness.version>
-        <!-- Other properties you may want to use:
-             ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
-             ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
-        -->
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <artifactId>stashNotifier</artifactId>
     <version>${revision}${changelist}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.10</version>
+        <version>3.36</version>
         <relativePath />
     </parent>
     <packaging>hpi</packaging>
@@ -11,9 +11,9 @@
         <revision>1.18</revision>
         <changelist>-SNAPSHOT</changelist>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>1.625.3</jenkins.version>
+        <jenkins.version>2.60.3</jenkins.version>
         <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
-        <java.level>7</java.level>
+        <java.level>8</java.level>
         <!-- Jenkins Test Harness version you use to test the plugin. -->
         <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
         <jenkins-test-harness.version>2.48</jenkins-test-harness.version>
@@ -142,6 +142,18 @@
             <artifactId>token-macro</artifactId>
             <version>2.0</version>
             <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>1.8</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.level>7</java.level>
         <!-- Jenkins Test Harness version you use to test the plugin. -->
         <!-- For Jenkins version >= 1.580.1 use JTH 2.x or higher. -->
-        <jenkins-test-harness.version>2.19</jenkins-test-harness.version>
+        <jenkins-test-harness.version>2.48</jenkins-test-harness.version>
         <!-- Other properties you may want to use:
              ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..
              ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -660,15 +660,6 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             this.includeBuildNumberInKey = includeBuildNumberInKey;
         }
 
-        public String getProjectKey() {
-            return projectKey;
-        }
-
-        @DataBoundSetter
-        public void setProjectKey(String projectKey) {
-            this.projectKey = StringUtils.trimToNull(projectKey);
-        }
-
         public boolean isPrependParentProjectKey() {
             return prependParentProjectKey;
         }
@@ -676,6 +667,15 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         @DataBoundSetter
         public void setPrependParentProjectKey(boolean prependParentProjectKey) {
             this.prependParentProjectKey = prependParentProjectKey;
+        }
+
+        public String getProjectKey() {
+            return projectKey;
+        }
+
+        @DataBoundSetter
+        public void setProjectKey(String projectKey) {
+            this.projectKey = StringUtils.trimToNull(projectKey);
         }
 
         public String getStashRootUrl() {

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -666,7 +666,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
         @DataBoundSetter
         public void setProjectKey(String projectKey) {
-            this.projectKey =  StringUtils.trimToNull(projectKey);
+            this.projectKey = StringUtils.trimToNull(projectKey);
         }
 
         public boolean isPrependParentProjectKey() {
@@ -679,11 +679,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         }
 
         public String getStashRootUrl() {
-            if ((stashRootUrl == null) || (stashRootUrl.trim().isEmpty())) {
-                return null;
-            } else {
-                return stashRootUrl;
-            }
+            return stashRootUrl;
         }
 
         @DataBoundSetter

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -611,33 +611,65 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             }
         }
 
+        public void setStashRootUrl(String stashRootUrl) {
+			this.stashRootUrl = stashRootUrl;
+		}
+
         public boolean isDisableInprogressNotification() {
             return disableInprogressNotification;
         }
 
+        public void setDisableInprogressNotification(boolean disableInprogressNotification) {
+			this.disableInprogressNotification = disableInprogressNotification;
+		}
+
         public boolean isConsiderUnstableAsSuccess() {
             return considerUnstableAsSuccess;
+        }
+
+        public void setConsiderUnstableAsSuccess(boolean considerUnstableAsSuccess) {
+            this.considerUnstableAsSuccess = considerUnstableAsSuccess;
         }
 
         public String getCredentialsId() {
             return credentialsId;
         }
 
+        public void setCredentialsId(String credentialsId) {
+			this.credentialsId = credentialsId;
+		}
+
         public boolean isIgnoreUnverifiedSsl() {
             return ignoreUnverifiedSsl;
         }
+
+        public void setIgnoreUnverifiedSsl(boolean ignoreUnverifiedSsl) {
+			this.ignoreUnverifiedSsl = ignoreUnverifiedSsl;
+		}
 
         public boolean isIncludeBuildNumberInKey() {
             return includeBuildNumberInKey;
         }
 
+        public void setIncludeBuildNumberInKey(boolean includeBuildNumberInKey) {
+			this.includeBuildNumberInKey = includeBuildNumberInKey;
+		}
+
         public String getProjectKey() {
             return projectKey;
         }
 
+        public void setProjectKey(String projectKey) {
+			this.projectKey = projectKey;
+		}
+
         public boolean isPrependParentProjectKey() {
             return prependParentProjectKey;
         }
+
+        public void setPrependParentProjectKey(boolean prependParentProjectKey) {
+			this.prependParentProjectKey = prependParentProjectKey;
+		}
 
         public FormValidation doCheckCredentialsId(@QueryParameter String value, @AncestorInPath Item project)
                 throws IOException, ServletException {

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -69,10 +69,7 @@ import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
-import org.kohsuke.stapler.AncestorInPath;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.*;
 
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLContext;
@@ -311,10 +308,6 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
     private String getRootUrl() {
         Jenkins instance = Jenkins.getInstance();
 
-        if (null == instance) {
-            return globalConfig.getUrl();
-        }
-
         return (instance.getRootUrl() != null) ? instance.getRootUrl() : globalConfig.getUrl();
     }
 
@@ -531,10 +524,6 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
     private void configureProxy(HttpClientBuilder builder, URL url) {
         Jenkins jenkins = Jenkins.getInstance();
-        if (jenkins == null) {
-            return;
-        }
-
         ProxyConfiguration proxyConfig = jenkins.proxy;
         if (proxyConfig == null) {
             return;
@@ -637,22 +626,25 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             }
         }
 
+        @DataBoundSetter
         public void setStashRootUrl(String stashRootUrl) {
-			this.stashRootUrl = stashRootUrl;
-		}
+            this.stashRootUrl = stashRootUrl;
+        }
 
         public boolean isDisableInprogressNotification() {
             return disableInprogressNotification;
         }
 
+        @DataBoundSetter
         public void setDisableInprogressNotification(boolean disableInprogressNotification) {
-			this.disableInprogressNotification = disableInprogressNotification;
-		}
+            this.disableInprogressNotification = disableInprogressNotification;
+        }
 
         public boolean isConsiderUnstableAsSuccess() {
             return considerUnstableAsSuccess;
         }
 
+        @DataBoundSetter
         public void setConsiderUnstableAsSuccess(boolean considerUnstableAsSuccess) {
             this.considerUnstableAsSuccess = considerUnstableAsSuccess;
         }
@@ -661,41 +653,45 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             return credentialsId;
         }
 
+        @DataBoundSetter
         public void setCredentialsId(String credentialsId) {
-			this.credentialsId = credentialsId;
-		}
+            this.credentialsId = credentialsId;
+        }
 
         public boolean isIgnoreUnverifiedSsl() {
             return ignoreUnverifiedSsl;
         }
 
+        @DataBoundSetter
         public void setIgnoreUnverifiedSsl(boolean ignoreUnverifiedSsl) {
-			this.ignoreUnverifiedSsl = ignoreUnverifiedSsl;
-		}
+            this.ignoreUnverifiedSsl = ignoreUnverifiedSsl;
+        }
 
         public boolean isIncludeBuildNumberInKey() {
             return includeBuildNumberInKey;
         }
 
+        @DataBoundSetter
         public void setIncludeBuildNumberInKey(boolean includeBuildNumberInKey) {
-			this.includeBuildNumberInKey = includeBuildNumberInKey;
-		}
+            this.includeBuildNumberInKey = includeBuildNumberInKey;
+        }
 
         public String getProjectKey() {
             return projectKey;
         }
 
         public void setProjectKey(String projectKey) {
-			this.projectKey = projectKey;
-		}
+            this.projectKey = projectKey;
+        }
 
         public boolean isPrependParentProjectKey() {
             return prependParentProjectKey;
         }
 
+        @DataBoundSetter
         public void setPrependParentProjectKey(boolean prependParentProjectKey) {
-			this.prependParentProjectKey = prependParentProjectKey;
-		}
+            this.prependParentProjectKey = prependParentProjectKey;
+        }
 
         public FormValidation doCheckCredentialsId(@QueryParameter String value, @AncestorInPath Item project)
                 throws IOException, ServletException {
@@ -752,26 +748,20 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
                 StaplerRequest req,
                 JSONObject formData) throws FormException {
 
-            // to persist global configuration information,
-            // set that to properties and call save().
-            stashRootUrl = formData.getString("stashRootUrl");
-            ignoreUnverifiedSsl = formData.getBoolean("ignoreUnverifiedSsl");
-            includeBuildNumberInKey = formData.getBoolean("includeBuildNumberInKey");
+            this.stashRootUrl = null;
+            this.ignoreUnverifiedSsl = false;
+            this.includeBuildNumberInKey = false;
+            this.credentialsId = null;
+            this.projectKey = null;
+            this.prependParentProjectKey = false;
+            this.disableInprogressNotification = false;
+            this.considerUnstableAsSuccess = false;
 
-            if (formData.has("credentialsId") && StringUtils.isNotBlank(formData.getString("credentialsId"))) {
-                credentialsId = formData.getString("credentialsId");
-            }
-            if (formData.has("projectKey")) {
-                projectKey = formData.getString("projectKey");
-            }
-            prependParentProjectKey = formData.getBoolean("prependParentProjectKey");
-
-            disableInprogressNotification = formData.getBoolean("disableInprogressNotification");
-
-            considerUnstableAsSuccess = formData.getBoolean("considerUnstableAsSuccess");
+            req.bindJSON(this, formData);
 
             save();
-            return super.configure(req, formData);
+
+            return true;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -21,10 +21,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.*;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
-import hudson.Extension;
-import hudson.FilePath;
-import hudson.Launcher;
-import hudson.ProxyConfiguration;
+import hudson.*;
 import hudson.model.*;
 import hudson.plugins.git.Revision;
 import hudson.plugins.git.util.BuildData;
@@ -573,14 +570,14 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
          * If you don't want fields to be persisted, use <tt>transient</tt>.
          */
 
+        private boolean considerUnstableAsSuccess;
         private String credentialsId;
-        private String stashRootUrl;
+        private boolean disableInprogressNotification;
         private boolean ignoreUnverifiedSsl;
         private boolean includeBuildNumberInKey;
-        private String projectKey;
         private boolean prependParentProjectKey;
-        private boolean disableInprogressNotification;
-        private boolean considerUnstableAsSuccess;
+        private String projectKey;
+        private String stashRootUrl;
 
         public DescriptorImpl() {
             this(true);
@@ -618,28 +615,6 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             return new StandardListBoxModel();
         }
 
-        public String getStashRootUrl() {
-            if ((stashRootUrl == null) || (stashRootUrl.trim().isEmpty())) {
-                return null;
-            } else {
-                return stashRootUrl;
-            }
-        }
-
-        @DataBoundSetter
-        public void setStashRootUrl(String stashRootUrl) {
-            this.stashRootUrl = stashRootUrl;
-        }
-
-        public boolean isDisableInprogressNotification() {
-            return disableInprogressNotification;
-        }
-
-        @DataBoundSetter
-        public void setDisableInprogressNotification(boolean disableInprogressNotification) {
-            this.disableInprogressNotification = disableInprogressNotification;
-        }
-
         public boolean isConsiderUnstableAsSuccess() {
             return considerUnstableAsSuccess;
         }
@@ -655,7 +630,16 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
         @DataBoundSetter
         public void setCredentialsId(String credentialsId) {
-            this.credentialsId = credentialsId;
+            this.credentialsId = StringUtils.trimToNull(credentialsId);
+        }
+
+        public boolean isDisableInprogressNotification() {
+            return disableInprogressNotification;
+        }
+
+        @DataBoundSetter
+        public void setDisableInprogressNotification(boolean disableInprogressNotification) {
+            this.disableInprogressNotification = disableInprogressNotification;
         }
 
         public boolean isIgnoreUnverifiedSsl() {
@@ -680,8 +664,9 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             return projectKey;
         }
 
+        @DataBoundSetter
         public void setProjectKey(String projectKey) {
-            this.projectKey = projectKey;
+            this.projectKey =  StringUtils.trimToNull(projectKey);
         }
 
         public boolean isPrependParentProjectKey() {
@@ -691,6 +676,19 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         @DataBoundSetter
         public void setPrependParentProjectKey(boolean prependParentProjectKey) {
             this.prependParentProjectKey = prependParentProjectKey;
+        }
+
+        public String getStashRootUrl() {
+            if ((stashRootUrl == null) || (stashRootUrl.trim().isEmpty())) {
+                return null;
+            } else {
+                return stashRootUrl;
+            }
+        }
+
+        @DataBoundSetter
+        public void setStashRootUrl(String stashRootUrl) {
+            this.stashRootUrl = StringUtils.trimToNull(stashRootUrl);
         }
 
         public FormValidation doCheckCredentialsId(@QueryParameter String value, @AncestorInPath Item project)
@@ -748,14 +746,14 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
                 StaplerRequest req,
                 JSONObject formData) throws FormException {
 
-            this.stashRootUrl = null;
+            this.considerUnstableAsSuccess = false;
+            this.credentialsId = null;
+            this.disableInprogressNotification = false;
             this.ignoreUnverifiedSsl = false;
             this.includeBuildNumberInKey = false;
-            this.credentialsId = null;
-            this.projectKey = null;
             this.prependParentProjectKey = false;
-            this.disableInprogressNotification = false;
-            this.considerUnstableAsSuccess = false;
+            this.projectKey = null;
+            this.stashRootUrl = null;
 
             req.bindJSON(this, formData);
 

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest.java
@@ -24,13 +24,14 @@ public class ConfigAsCodeTest {
         ConfigurationAsCode.get().configure(configFileUrl.toString());
         StashNotifier.DescriptorImpl stashNotifierConfig = rule.jenkins.getDescriptorByType(StashNotifier.DescriptorImpl.class);
 
+        assertThat(stashNotifierConfig.isConsiderUnstableAsSuccess(), equalTo(true));
         assertThat(stashNotifierConfig.getCredentialsId(), equalTo("bitbucket-credentials"));
+        assertThat(stashNotifierConfig.isDisableInprogressNotification(), equalTo(true));
         assertThat(stashNotifierConfig.isIgnoreUnverifiedSsl(), equalTo(true));
         assertThat(stashNotifierConfig.isIncludeBuildNumberInKey(), equalTo(true));
-        assertThat(stashNotifierConfig.getProjectKey(), equalTo("JEN"));
         assertThat(stashNotifierConfig.isPrependParentProjectKey(), equalTo(true));
-        assertThat(stashNotifierConfig.isDisableInprogressNotification(), equalTo(true));
-        assertThat(stashNotifierConfig.isConsiderUnstableAsSuccess(), equalTo(true));
+        assertThat(stashNotifierConfig.getProjectKey(), equalTo("JEN"));
+        assertThat(stashNotifierConfig.getStashRootUrl(), equalTo("https://my.company.intranet/bitbucket"));
     }
 
     @Test
@@ -44,7 +45,7 @@ public class ConfigAsCodeTest {
         stashNotifierConfig.setIncludeBuildNumberInKey(true);
         stashNotifierConfig.setPrependParentProjectKey(true);
         stashNotifierConfig.setProjectKey("JEN");
-        stashNotifierConfig.setStashRootUrl("https://bitbucket.com");
+        stashNotifierConfig.setStashRootUrl("https://my.company.intranet/bitbucket");
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         ConfigurationAsCode.get().export(outputStream);

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest.java
@@ -1,0 +1,60 @@
+package org.jenkinsci.plugins.stashNotifier;
+
+import hudson.util.IOUtils;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ConfigAsCodeTest {
+    @Rule
+    public JenkinsRule rule = new JenkinsRule();
+
+    @Test
+    public void should_support_jcasc_from_yaml() throws Exception {
+        URL configFileUrl = ConfigAsCodeTest.class.getResource(getClass().getSimpleName() + "/configuration-as-code.yml");
+        ConfigurationAsCode.get().configure(configFileUrl.toString());
+        StashNotifier.DescriptorImpl stashNotifierConfig = rule.jenkins.getDescriptorByType(StashNotifier.DescriptorImpl.class);
+
+        assertThat(stashNotifierConfig.getCredentialsId(), equalTo("bitbucket-credentials"));
+        assertThat(stashNotifierConfig.isIgnoreUnverifiedSsl(), equalTo(true));
+        assertThat(stashNotifierConfig.isIncludeBuildNumberInKey(), equalTo(true));
+        assertThat(stashNotifierConfig.getProjectKey(), equalTo("JEN"));
+        assertThat(stashNotifierConfig.isPrependParentProjectKey(), equalTo(true));
+        assertThat(stashNotifierConfig.isDisableInprogressNotification(), equalTo(true));
+        assertThat(stashNotifierConfig.isConsiderUnstableAsSuccess(), equalTo(true));
+    }
+
+    @Test
+    public void should_support_jcasc_to_yaml() throws Exception {
+        StashNotifier.DescriptorImpl stashNotifierConfig = rule.jenkins.getDescriptorByType(StashNotifier.DescriptorImpl.class);
+
+        stashNotifierConfig.setConsiderUnstableAsSuccess(true);
+        stashNotifierConfig.setCredentialsId("bitbucket-credentials");
+        stashNotifierConfig.setDisableInprogressNotification(true);
+        stashNotifierConfig.setIgnoreUnverifiedSsl(true);
+        stashNotifierConfig.setIncludeBuildNumberInKey(true);
+        stashNotifierConfig.setPrependParentProjectKey(true);
+        stashNotifierConfig.setProjectKey("JEN");
+        stashNotifierConfig.setStashRootUrl("https://bitbucket.com");
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ConfigurationAsCode.get().export(outputStream);
+        String exportedYaml = outputStream.toString("UTF-8");
+
+        InputStream yamlStream = getClass().getResourceAsStream(getClass().getSimpleName() + "/configuration-as-code.yml");
+        String expectedYaml = IOUtils.toString(yamlStream, "UTF-8")
+                .replaceAll("\r\n?", "\n")
+                .replace("unclassified:\n", "");
+
+        assertThat(exportedYaml, containsString(expectedYaml));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
@@ -77,14 +77,14 @@ public class DescriptorImplTest {
         //given
         doNothing().when(desc).save();
 
-        ServletContext servletContext = PowerMockito.mock(ServletContext.class);
+        ServletContext servletContext = mock(ServletContext.class);
         WebApp webApp = new WebApp(servletContext);
 
-        Stapler stapler = PowerMockito.mock(Stapler.class);
-        PowerMockito.when(stapler.getWebApp()).thenReturn(webApp);
+        Stapler stapler = mock(Stapler.class);
+        when(stapler.getWebApp()).thenReturn(webApp);
 
-        HttpServletRequest servletRequest = PowerMockito.mock(HttpServletRequest.class);
-        TokenList tokenList = PowerMockito.mock(TokenList.class);
+        HttpServletRequest servletRequest = mock(HttpServletRequest.class);
+        TokenList tokenList = mock(TokenList.class);
 
         RequestImpl staplerRequest = new RequestImpl(stapler, servletRequest, new ArrayList<>(), tokenList);
 

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
@@ -73,21 +73,13 @@ public class DescriptorImplTest {
     public void testConfigure() throws Descriptor.FormException {
         //given
         doNothing().when(desc).save();
+        StaplerRequest request = mock(StaplerRequest.class);
 
         //when
-        desc.configure(mock(StaplerRequest.class), json);
+        desc.configure(request, json);
 
         //then
-        assertThat(desc.getStashRootUrl(), is("http://stash-root-url"));
-        assertThat(desc.getCredentialsId(), is("someCredentialsId"));
-        assertThat(desc.getProjectKey(), is("someProjectKey"));
-        assertThat(desc.getDisplayName(), is("Notify Stash Instance"));
-        assertThat(desc.isDisableInprogressNotification(), is(true));
-        assertThat(desc.isConsiderUnstableAsSuccess(), is(true));
-        assertThat(desc.isIgnoreUnverifiedSsl(), is(true));
-        assertThat(desc.isIncludeBuildNumberInKey(), is(true));
-        assertThat(desc.isPrependParentProjectKey(), is(true));
-        assertThat(desc.isApplicable(AbstractProject.class), is(true));
+        verify(request).bindJSON(desc, json);
     }
 
     @Test

--- a/src/test/resources/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest/configuration-as-code.yml
+++ b/src/test/resources/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest/configuration-as-code.yml
@@ -1,0 +1,10 @@
+unclassified:
+  notifyBitbucket:
+    considerUnstableAsSuccess: true
+    credentialsId: "bitbucket-credentials"
+    disableInprogressNotification: true
+    ignoreUnverifiedSsl: true
+    includeBuildNumberInKey: true
+    prependParentProjectKey: true
+    projectKey: "JEN"
+    stashRootUrl: "https://bitbucket.com"

--- a/src/test/resources/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest/configuration-as-code.yml
+++ b/src/test/resources/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest/configuration-as-code.yml
@@ -7,4 +7,4 @@ unclassified:
     includeBuildNumberInKey: true
     prependParentProjectKey: true
     projectKey: "JEN"
-    stashRootUrl: "https://bitbucket.com"
+    stashRootUrl: "https://my.company.intranet/bitbucket"


### PR DESCRIPTION
In order to be able to configure this plugin using the [Configuration As Code plugin](https://github.com/jenkinsci/configuration-as-code-plugin), the StashNotifier.DescriptorImpl needs to have setters or public fields. Using YAML to configure Jenkins is pretty nice and this would enable this to work with this plugin as well.