### PR TITLE
Add note about requiring Jenkins Git plugin

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ Requirements
 * **[Stash][] 2.1** or newer. This plugin uses the Atlassian 
 [Stash Build REST API][] which was introduced with Stash 2.1. 
 * **Jenkins 1.498** or newer
+* ** Jenkins Git plugin version 4.0.0-rc or later
 
 Setup
 =====


### PR DESCRIPTION
Document that only versions 4.0.0-rc and above of the Jenkins Git plugin are supported