### PR TITLE
Remove option to set project key globally (was broken)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -576,7 +576,6 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         private boolean ignoreUnverifiedSsl;
         private boolean includeBuildNumberInKey;
         private boolean prependParentProjectKey;
-        private String projectKey;
         private String stashRootUrl;
 
         public DescriptorImpl() {
@@ -669,15 +668,6 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             this.prependParentProjectKey = prependParentProjectKey;
         }
 
-        public String getProjectKey() {
-            return projectKey;
-        }
-
-        @DataBoundSetter
-        public void setProjectKey(String projectKey) {
-            this.projectKey = StringUtils.trimToNull(projectKey);
-        }
-
         public String getStashRootUrl() {
             return stashRootUrl;
         }
@@ -748,7 +738,6 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             this.ignoreUnverifiedSsl = false;
             this.includeBuildNumberInKey = false;
             this.prependParentProjectKey = false;
-            this.projectKey = null;
             this.stashRootUrl = null;
 
             req.bindJSON(this, formData);
@@ -1005,8 +994,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             }
         }
 
-        String overriddenKey = (projectKey != null && projectKey.trim().length() > 0) ? projectKey : getDescriptor().getProjectKey();
-        if (overriddenKey != null && overriddenKey.trim().length() > 0) {
+        if (projectKey != null && projectKey.trim().length() > 0) {
             PrintStream logger = listener.getLogger();
             try {
                 if (!(run instanceof AbstractBuild<?, ?>)) {

--- a/src/main/webapp/help-globalConfig-projectKey.html
+++ b/src/main/webapp/help-globalConfig-projectKey.html
@@ -1,5 +1,0 @@
-<div>
-    <p>
-        Override project key for all notifies
-    </p>
-</div>

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest.java
@@ -30,7 +30,6 @@ public class ConfigAsCodeTest {
         assertThat(stashNotifierConfig.isIgnoreUnverifiedSsl(), equalTo(true));
         assertThat(stashNotifierConfig.isIncludeBuildNumberInKey(), equalTo(true));
         assertThat(stashNotifierConfig.isPrependParentProjectKey(), equalTo(true));
-        assertThat(stashNotifierConfig.getProjectKey(), equalTo("JEN"));
         assertThat(stashNotifierConfig.getStashRootUrl(), equalTo("https://my.company.intranet/bitbucket"));
     }
 
@@ -44,7 +43,6 @@ public class ConfigAsCodeTest {
         stashNotifierConfig.setIgnoreUnverifiedSsl(true);
         stashNotifierConfig.setIncludeBuildNumberInKey(true);
         stashNotifierConfig.setPrependParentProjectKey(true);
-        stashNotifierConfig.setProjectKey("JEN");
         stashNotifierConfig.setStashRootUrl("https://my.company.intranet/bitbucket");
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
@@ -99,7 +99,6 @@ public class DescriptorImplTest {
         assertThat(desc.isIncludeBuildNumberInKey(), is(true));
         assertThat(desc.isIgnoreUnverifiedSsl(), is(true));
         assertThat(desc.isPrependParentProjectKey(), is(true));
-        assertThat(desc.getProjectKey(), is("JEN"));
         assertThat(desc.getStashRootUrl(), is("https://my.company.intranet/bitbucket"));
     }
 

--- a/src/test/resources/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest/configuration-as-code.yml
+++ b/src/test/resources/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest/configuration-as-code.yml
@@ -6,5 +6,4 @@ unclassified:
     ignoreUnverifiedSsl: true
     includeBuildNumberInKey: true
     prependParentProjectKey: true
-    projectKey: "JEN"
     stashRootUrl: "https://my.company.intranet/bitbucket"


### PR DESCRIPTION
The project key feature was introduced in commit 04a09cc45370.

The implementation had two flaws:
1) It contained `projectKey` in the Descriptor but did not provide this field in the UI (global.jelly).
2) The `getBuildKey()` method only used the global project key in one place. When expanding macros, only the job specific key was used.