### PR TITLE
pom.xml: Make guava a test requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,11 +83,6 @@
             <version>1.1.1</version>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>19.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.8</version>
@@ -133,6 +128,12 @@
             <artifactId>token-macro</artifactId>
             <version>2.0</version>
             <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
It is not needed for running the plugin and should not be packaged into
stashNotifier.hpi.

Guava was the largest contributor to the plugin size.

The plugin has been tested on Jenkins to make sure it works and posts notifications to Stash.