### PR TITLE
pom.xml: Use Apache HttpComponents Client 4.x API Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,9 @@
             <version>1.1.1</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.8</version>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
+            <version>4.5.5-3.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
This removes httpclient-4.5.8.jar and httpcore-4.4.11.jar from the plugin
package, cutting its size by over a megabyte.

Users can update the Apache HttpComponents plugin on their own without
waiting for other plugins to update their dependencies.

Apache HttpComponents plugin is likely to be installed already because
it's used by the git plugin.

This resolves #205. The only remaining bundled jar is `sshd-core-0.14.0.jar`