### PR TITLE
pom.xml: Fix bundling of sshd-core.jar, update git dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.0</version>
+            <version>3.0.0</version>
             <type>jar</type>
         </dependency>
         <dependency>


### PR DESCRIPTION
git 2.0 has problematic dependencies that makes the hpi plugin bundle `sshd-code.jar` into the plugin.

Update git dependency to 3.0.0. That fixes the bundling issue.

Thanks to @jglick for suggesting the fix in https://issues.jenkins-ci.org/browse/JENKINS-53957

---

The size of Stash Notifier plugin was totally unreasonable before of bundling. That issue is fully resolved now.

The size of stashNotifier.hpi is 27349 bytes! Yes, it's functional, I've checked it on my test server.

git plugin 3.0.0 was released in September 2016, so this PR doesn't force users to upgrade to anything unreasonably new. I was contemplating using git 3.11.0, but that could make some overly conservative Jenkins admins unhappy.

I don't think the dependency on the git plugin is really needed, but if we remove it, it would be a much bigger change, as its dependencies would need to be listed instead. It can be done separately.