### PR TITLE
pom.xml: Use GitHub for plugin's documentation on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         Jenkins plugin to notify Atlassian Bitbucket Server (formerly known as Stash)
         instances of build results through the REST build API.
     </description>
-    <url>https://wiki.jenkins.io/display/JENKINS/Bitbucket+(Stash)+Notifier+Plugin</url>
+    <url>https://github.com/jenkinsci/stashnotifier-plugin</url>
 
     <scm>
         <connection>scm:git:https://github.com/jenkinsci/stashnotifier-plugin.git</connection>


### PR DESCRIPTION
The plugin description on the plugin page is short and incomplete. This
change will replace the plugin page with a better page based on the
readme.md file from GitHub. The change will take effect when the next
version of the plugin is released.

See https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A and
https://issues.jenkins-ci.org/browse/WEBSITE-406 for details.