### PR TITLE
Simplify setting "compatibleSinceVersion"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
         <jenkins.version>2.60.3</jenkins.version>
         <java.level>8</java.level>
+        <hpi.compatibleSinceVersion>1.9</hpi.compatibleSinceVersion>
     </properties>
     <artifactId>stashNotifier</artifactId>
     <version>${revision}${changelist}</version>
@@ -172,14 +173,6 @@
                     <excludes>
                         <exclude>InjectedTest.java</exclude>
                     </excludes>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <compatibleSinceVersion>1.9</compatibleSinceVersion>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
The used property is available since maven-hpi-plugin 3.2.
See https://github.com/jenkinsci/maven-hpi-plugin/blob/maven-hpi-plugin-3.2/README.md.