### PR TITLE
Enable InjectedTest & fix found issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>display-url-api</artifactId>
-            <version>1.1.1</version>
+            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>1.22</version>
+            <version>2.1.4</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -125,6 +125,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>2.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
             <version>2.0</version>
@@ -149,32 +155,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>display-info</id>
-                            <configuration>
-                                <skip>true</skip>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>InjectedTest.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the installed plugins page.
 -->

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:advanced>
     <f:entry title="Server base URL" field="stashServerBaseUrl">
@@ -5,8 +6,8 @@
     </f:entry>
     <f:entry title="${%Credentials}" field="credentialsId">
       <c:select/>
-     </f:entry>
-     <f:entry title="Commit SHA-1" field="commitSha1">
+    </f:entry>
+    <f:entry title="Commit SHA-1" field="commitSha1">
       <f:textbox />
     </f:entry>
     <f:entry title="Ignore unverified SSL certificates" field="ignoreUnverifiedSSLPeer">

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:section title="Bitbucket Server Notifier">
     <f:entry title="Server base URL"

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest.java
@@ -10,7 +10,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.net.URL;
 
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
@@ -55,7 +55,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;


### PR DESCRIPTION
- enable maven-enforcer-plugin to show plugin incompatibilities & fix them
  - without these changes the plugin would fail to start in InjectedTest
  - "git client" plugin v2.0.0 requires "structs" plugin v1.3 or later
    (it was a transitive dependency via "display-url-api" plugin v1.1.1)
  - "git" plugin v3.0.0 requires "credentials" plugin v2.1.4 or later
- all .jelly files should escape content per default
  - this was reported via InjectedTest
  - also see https://wiki.jenkins.io/display/JENKINS/Jelly+and+XSS+prevention
- explicit Hamcrest dependency declaration
  - Hamcrest is used in the tests and therefore should be declared explicitly
  - use the highest version to resolve version conflicts due to transisitivy