### PR TITLE
Inline "lookupCredentials" methods

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -22,7 +22,6 @@ import com.cloudbees.plugins.credentials.common.CertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
-import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -41,7 +40,6 @@ import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
-import org.acegisecurity.Authentication;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpEntity;
@@ -811,7 +809,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         String credentialsId = getCredentialsId();
         if (StringUtils.isNotBlank(credentialsId) && clazz != null && project != null) {
             credentials = CredentialsMatchers.firstOrNull(
-                    lookupCredentials(clazz, project, ACL.SYSTEM, new ArrayList<>()),
+                    CredentialsProvider.lookupCredentials(clazz, project, ACL.SYSTEM, new ArrayList<>()),
                     CredentialsMatchers.withId(credentialsId));
         }
 
@@ -822,42 +820,12 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             }
             if (StringUtils.isNotBlank(credentialsId) && clazz != null && project != null) {
                 credentials = CredentialsMatchers.firstOrNull(
-                        lookupCredentials(clazz, Jenkins.getInstance(), ACL.SYSTEM, new ArrayList<>()),
+                        CredentialsProvider.lookupCredentials(clazz, Jenkins.getInstance(), ACL.SYSTEM, new ArrayList<>()),
                         CredentialsMatchers.withId(credentialsId));
             }
         }
 
         return credentials;
-    }
-
-    /**
-     * Returns all credentials which are available to the specified {@link Authentication}
-     * for use by the specified {@link Item}.
-     *
-     * @param type               the type of credentials to get.
-     * @param authentication     the authentication.
-     * @param item               the item.
-     * @param domainRequirements the credential domains to match.
-     * @param <C>                the credentials type.
-     * @return the list of credentials.
-     */
-    protected <C extends Credentials> List<C> lookupCredentials(Class<C> type, Item item, Authentication authentication, ArrayList<DomainRequirement> domainRequirements) {
-        return CredentialsProvider.lookupCredentials(type, item, authentication, domainRequirements);
-    }
-
-    /**
-     * Returns all credentials which are available to the specified {@link Authentication}
-     * for use by the specified {@link Item}.
-     *
-     * @param type               the type of credentials to get.
-     * @param authentication     the authentication.
-     * @param itemGroup          the item group.
-     * @param domainRequirements the credential domains to match.
-     * @param <C>                the credentials type.
-     * @return the list of credentials.
-     */
-    protected <C extends Credentials> List<C> lookupCredentials(Class<C> type, ItemGroup<?> itemGroup, Authentication authentication, ArrayList<DomainRequirement> domainRequirements) {
-        return CredentialsProvider.lookupCredentials(type, itemGroup, authentication, domainRequirements);
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
@@ -40,7 +40,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -182,13 +181,6 @@ public class StashNotifierTest {
     @Test
     public void test_build_http_client_with_proxy() throws Exception {
         //given
-        StashNotifier sn = spy(this.sn);
-        doReturn(new ArrayList<Credentials>()).when(sn).lookupCredentials(
-                Mockito.<Class>anyObject(),
-                Mockito.<Item>anyObject(),
-                Mockito.<Authentication>anyObject(),
-                Mockito.<ArrayList<DomainRequirement>>anyObject());
-
         String address = "192.168.1.1";
         int port = 8080;
         String login = "admin";
@@ -230,7 +222,7 @@ public class StashNotifierTest {
     @Test
     public void test_build_http_client_https() throws Exception {
         //given
-        sn = spy(new StashNotifier(
+        sn = new StashNotifier(
                 "https://localhost",
                 "scot",
                 true,
@@ -242,13 +234,8 @@ public class StashNotifierTest {
                 false,
                 false,
                 false,
-                mock(JenkinsLocationConfiguration.class)));
+                mock(JenkinsLocationConfiguration.class));
 
-        doReturn(new ArrayList<Credentials>()).when(sn).lookupCredentials(
-                Mockito.<Class>anyObject(),
-                Mockito.<Item>anyObject(),
-                Mockito.<Authentication>anyObject(),
-                Mockito.<ArrayList<DomainRequirement>>anyObject());
         PrintStream logger = mock(PrintStream.class);
 
         //when
@@ -576,15 +563,7 @@ public class StashNotifierTest {
     @Test
     public void test_createRequest() throws Exception {
         //given
-        StashNotifier sn = spy(this.sn);
-        ArrayList<Credentials> credentialList = new ArrayList<>();
         UsernamePasswordCredentialsImpl credential = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "", "", "admin", "tiger");
-        credentialList.add(credential);
-        doReturn(credentialList).when(sn).lookupCredentials(
-                Mockito.<Class>anyObject(),
-                Mockito.<Item>anyObject(),
-                Mockito.<Authentication>anyObject(),
-                Mockito.<ArrayList<DomainRequirement>>anyObject());
         PowerMockito.mockStatic(CredentialsMatchers.class);
         when(CredentialsMatchers.firstOrNull(anyCollection(), any(CredentialsMatcher.class))).thenReturn(credential);
 


### PR DESCRIPTION
There was a mix of the `lookupCredentials` wrapper methods and using `CredentialsProvider#lookupCredentials` directly. This also resulted in different ways of mocking these calls in the tests.

As the mentioned methods were originally introduced for mocking purposes and PowerMockito now is anyway used in the tests to mock static methods, there is no need for these wrapper methods anymore.