### PR TITLE
Allow to use Personal Access Token

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/NotificationSettings.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/NotificationSettings.java
@@ -9,10 +9,12 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
  */
 public class NotificationSettings {
     private final boolean ignoreUnverifiedSSL;
+    private final boolean tokenCredentials;
     private final UsernamePasswordCredentials credentials;
 
-    public NotificationSettings(boolean ignoreUnverifiedSSL, UsernamePasswordCredentials credentials) {
+    public NotificationSettings(boolean ignoreUnverifiedSSL, boolean tokenCredentials, UsernamePasswordCredentials credentials) {
         this.ignoreUnverifiedSSL = ignoreUnverifiedSSL;
+        this.tokenCredentials = tokenCredentials;
         this.credentials = credentials;
     }
 
@@ -20,6 +22,10 @@ public class NotificationSettings {
         return ignoreUnverifiedSSL;
     }
 
+    public boolean isTokenCredentials(){
+        return tokenCredentials;
+    }
+    
     @CheckForNull
     public UsernamePasswordCredentials getCredentials() {
         return credentials;

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -159,6 +159,11 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
      */
     private final boolean considerUnstableAsSuccess;
 
+    /**
+     * whether to use provided credials as Bitbucket Personal Access Token
+     */
+    private final boolean useCredentialsAsPersonalAccessToken;
+
     private final JenkinsLocationConfiguration globalConfig;
 
     /**
@@ -186,6 +191,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             boolean prependParentProjectKey,
             boolean disableInprogressNotification,
             boolean considerUnstableAsSuccess,
+            boolean useCredentialsAsPersonalAccessToken,
             JenkinsLocationConfiguration globalConfig
     ) {
 
@@ -210,6 +216,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         this.prependParentProjectKey = prependParentProjectKey;
         this.disableInprogressNotification = disableInprogressNotification;
         this.considerUnstableAsSuccess = considerUnstableAsSuccess;
+        this.useCredentialsAsPersonalAccessToken = useCredentialsAsPersonalAccessToken;
         this.globalConfig = globalConfig;
     }
 
@@ -225,7 +232,8 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             String projectKey,
             boolean prependParentProjectKey,
             boolean disableInprogressNotification,
-            boolean considerUnstableAsSuccess
+            boolean considerUnstableAsSuccess,
+            boolean useCredentialsAsPersonalAccessToken
     ) {
         this(
                 stashServerBaseUrl,
@@ -239,6 +247,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
                 prependParentProjectKey,
                 disableInprogressNotification,
                 considerUnstableAsSuccess,
+                useCredentialsAsPersonalAccessToken,
                 JenkinsLocationConfiguration.get()
         );
     }
@@ -249,6 +258,10 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
     public boolean isConsiderUnstableAsSuccess() {
         return considerUnstableAsSuccess;
+    }
+
+    public boolean isUseCredentialsAsPersonalAccessToken() {
+        return useCredentialsAsPersonalAccessToken;
     }
 
     public String getCredentialsId() {
@@ -610,7 +623,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         private boolean includeBuildNumberInKey;
         private boolean prependParentProjectKey;
         private String stashRootUrl;
-
+        private boolean useCredentialsAsPersonalAccessToken;
         public DescriptorImpl() {
             this(true);
         }
@@ -645,6 +658,15 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             }
 
             return new StandardListBoxModel();
+        }
+
+        public boolean isUseCredentialsAsPersonalAccessToken() {
+            return useCredentialsAsPersonalAccessToken;
+        }
+
+        @DataBoundSetter
+        public void setUseCredentialsAsPersonalAccessToken(boolean useCredentialsAsPersonalAccessToken) {
+            this.useCredentialsAsPersonalAccessToken = useCredentialsAsPersonalAccessToken;
         }
 
         public boolean isConsiderUnstableAsSuccess() {
@@ -764,7 +786,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         public boolean configure(
                 StaplerRequest req,
                 JSONObject formData) throws FormException {
-
+            this.useCredentialsAsPersonalAccessToken = false;
             this.considerUnstableAsSuccess = false;
             this.credentialsId = null;
             this.disableInprogressNotification = false;
@@ -811,7 +833,8 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
         URI uri = BuildStatusUriFactory.create(stashURL, commitSha1);
         NotificationSettings settings = new NotificationSettings(
-                ignoreUnverifiedSSLPeer || getDescriptor().isIgnoreUnverifiedSsl(),
+                ignoreUnverifiedSSLPeer || getDescriptor().isIgnoreUnverifiedSsl(), 
+                isUseCredentialsAsPersonalAccessToken() || getDescriptor().isUseCredentialsAsPersonalAccessToken(),
                 usernamePasswordCredentials
         );
         NotificationContext context = new NotificationContext(

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -833,8 +833,8 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
         URI uri = BuildStatusUriFactory.create(stashURL, commitSha1);
         NotificationSettings settings = new NotificationSettings(
-                ignoreUnverifiedSSLPeer || getDescriptor().isIgnoreUnverifiedSsl(), 
-                isUseCredentialsAsPersonalAccessToken() || getDescriptor().isUseCredentialsAsPersonalAccessToken(),
+                (ignoreUnverifiedSSLPeer || (getDescriptor() != null && getDescriptor().isIgnoreUnverifiedSsl())), 
+                (isUseCredentialsAsPersonalAccessToken() || (getDescriptor() != null && getDescriptor().isUseCredentialsAsPersonalAccessToken())),
                 usernamePasswordCredentials
         );
         NotificationContext context = new NotificationContext(

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
@@ -28,5 +28,8 @@
     <f:entry title="Consider UNSTABLE builds as SUCCESS notification" field="considerUnstableAsSuccess">
       <f:checkbox />
     </f:entry>
+    <f:entry title="Use credentials as Bitbucket Personal Access Token" field="useCredentialsAsPersonalAccessToken">
+      <f:checkbox />
+    </f:entry>    
   </f:advanced>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
@@ -34,5 +34,10 @@
              help="${rootURL}/plugin/stashNotifier/help-globalConfig-considerUnstableAsSuccess.html">
       <f:checkbox default="false"/>
     </f:entry>
+    <f:entry title="Use credentials as Bitbucket Personal Access Token"
+             field="useCredentialsAsPersonalAccessToken"
+             help="${rootURL}/plugin/stashNotifier/help-globalConfig-useCredentialsAsPersonalAccessToken.html">
+      <f:checkbox default="false"/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-useCredentialsAsPersonalAccessToken.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-useCredentialsAsPersonalAccessToken.html
@@ -1,0 +1,3 @@
+<div>
+    Use provided credentials as bearer token instead of basic auth.
+</div>

--- a/src/main/webapp/help-globalConfig-useCredentialsAsPersonalAccessToken.html
+++ b/src/main/webapp/help-globalConfig-useCredentialsAsPersonalAccessToken.html
@@ -1,0 +1,5 @@
+<div>
+    <p>
+        Check this if provided credentials contains access token instead of username and password.
+    </p>
+</div>

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/DefaultApacheHttpNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/DefaultApacheHttpNotifierTest.java
@@ -132,7 +132,7 @@ public class DefaultApacheHttpNotifierTest {
         when(resp.getStatusLine()).thenReturn(sl);
         when(resp.getEntity()).thenReturn(new StringEntity(""));
         when(client.execute(any(HttpPost.class))).thenReturn(resp);
-        return httpNotifier.send(uri, new JSONObject(), new NotificationSettings(false, null), new NotificationContext(logger, "some-build#15"));
+        return httpNotifier.send(uri, new JSONObject(), new NotificationSettings(false, false,null), new NotificationContext(logger, "some-build#15"));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
@@ -96,6 +96,7 @@ public class StashNotifierTest {
                 true,
                 disableInprogressNotification,
                 considerUnstableAsSuccess,
+                false,
                 mock(JenkinsLocationConfiguration.class)
         );
         notifier.setHttpNotifierSelector(httpNotifierSelector);
@@ -238,6 +239,7 @@ public class StashNotifierTest {
                 null,
                 true,
                 null,
+                false,
                 false,
                 false,
                 false,
@@ -493,6 +495,7 @@ public class StashNotifierTest {
                 false,
                 false,
                 false,
+                false,
                 mock(JenkinsLocationConfiguration.class));
 
         //when
@@ -518,6 +521,7 @@ public class StashNotifierTest {
                 null,
                 true,
                 null,
+                false,
                 false,
                 false,
                 false,
@@ -587,6 +591,7 @@ public class StashNotifierTest {
                 true,
                 false,
                 false,
+                false,
                 mock(JenkinsLocationConfiguration.class));
 
         //when
@@ -609,6 +614,7 @@ public class StashNotifierTest {
                 true,
                 null,
                 true,
+                false,
                 false,
                 false,
                 mock(JenkinsLocationConfiguration.class));
@@ -638,6 +644,7 @@ public class StashNotifierTest {
                 true,
                 false,
                 false,
+                false,
                 mock(JenkinsLocationConfiguration.class));
 
         //when
@@ -662,6 +669,7 @@ public class StashNotifierTest {
                 true,
                 null,
                 true,
+                false,
                 false,
                 false,
                 mock(JenkinsLocationConfiguration.class));
@@ -694,6 +702,7 @@ public class StashNotifierTest {
                 true,
                 false,
                 false,
+                false,
                 mock(JenkinsLocationConfiguration.class));
 
         //when
@@ -723,6 +732,7 @@ public class StashNotifierTest {
                 true,
                 null,
                 true,
+                false,
                 false,
                 false,
                 mock(JenkinsLocationConfiguration.class));
@@ -757,6 +767,7 @@ public class StashNotifierTest {
                 true,
                 false,
                 false,
+                false,
                 mock(JenkinsLocationConfiguration.class));
 
         //when
@@ -784,6 +795,7 @@ public class StashNotifierTest {
                 true,
                 key,
                 true,
+                false,
                 false,
                 false,
                 mock(JenkinsLocationConfiguration.class));
@@ -816,6 +828,7 @@ public class StashNotifierTest {
                 true,
                 key,
                 true,
+                false,
                 false,
                 false,
                 mock(JenkinsLocationConfiguration.class));


### PR DESCRIPTION
Allows to use Personal Access Tokens to send notifications to Bitbucket
(as requested in https://github.com/jenkinsci/stashnotifier-plugin/issues/216)

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
