### PR TITLE
Personal Access Token can be provide using secret text Credential

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/NotificationSettings.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/NotificationSettings.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.stashNotifier;
 
-import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.Credentials;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 
 /**
@@ -9,9 +9,9 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
  */
 public class NotificationSettings {
     private final boolean ignoreUnverifiedSSL;
-    private final UsernamePasswordCredentials credentials;
+    private final Credentials credentials;
 
-    public NotificationSettings(boolean ignoreUnverifiedSSL, UsernamePasswordCredentials credentials) {
+    public NotificationSettings(boolean ignoreUnverifiedSSL, Credentials credentials) {
         this.ignoreUnverifiedSSL = ignoreUnverifiedSSL;
         this.credentials = credentials;
     }
@@ -21,7 +21,7 @@ public class NotificationSettings {
     }
 
     @CheckForNull
-    public UsernamePasswordCredentials getCredentials() {
+    public Credentials getCredentials() {
         return credentials;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashCredentialMatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashCredentialMatcher.java
@@ -4,6 +4,9 @@ import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.common.CertificateCredentials;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -11,6 +14,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public class StashCredentialMatcher implements CredentialsMatcher {
     public boolean matches(@NonNull Credentials credentials) {
-        return (credentials instanceof CertificateCredentials) || (credentials instanceof UsernamePasswordCredentials);
+        return (credentials instanceof CertificateCredentials) || (credentials instanceof UsernamePasswordCredentials || (credentials instanceof StringCredentialsImpl));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashCredentialMatcher.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashCredentialMatcher.java
@@ -5,7 +5,7 @@ import com.cloudbees.plugins.credentials.CredentialsMatcher;
 import com.cloudbees.plugins.credentials.common.CertificateCredentials;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 
-import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -14,6 +14,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public class StashCredentialMatcher implements CredentialsMatcher {
     public boolean matches(@NonNull Credentials credentials) {
-        return (credentials instanceof CertificateCredentials) || (credentials instanceof UsernamePasswordCredentials || (credentials instanceof StringCredentialsImpl));
+        return (credentials instanceof CertificateCredentials) || (credentials instanceof UsernamePasswordCredentials || (credentials instanceof StringCredentials));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -66,6 +66,7 @@ import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.stapler.*;
@@ -806,13 +807,15 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
         logger.println("Notifying Bitbucket at \"" + stashURL + "\"");
 
-        UsernamePasswordCredentials usernamePasswordCredentials
+        Credentials usernamePasswordCredentials
                 = getCredentials(UsernamePasswordCredentials.class, run.getParent());
+        Credentials stringCredentials
+                = getCredentials(StringCredentials.class, run.getParent());
 
         URI uri = BuildStatusUriFactory.create(stashURL, commitSha1);
         NotificationSettings settings = new NotificationSettings(
                 ignoreUnverifiedSSLPeer || getDescriptor().isIgnoreUnverifiedSsl(),
-                usernamePasswordCredentials
+                stringCredentials != null ? stringCredentials : usernamePasswordCredentials
         );
         NotificationContext context = new NotificationContext(
                 logger,


### PR DESCRIPTION
Bitbucket Personal Access token can be provided using "secret text" Credential

https://github.com/jenkinsci/stashnotifier-plugin/issues/216

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
