### PR TITLE
Fix setBuildStatus to handle both String and StashBuildState arguments in a single method

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -251,15 +251,17 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         return buildStatus;
     }
 
-    public void setBuildStatus(StashBuildState buildStatus) {
-        this.buildStatus = buildStatus;
-    }
-
     @DataBoundSetter
-    public void setBuildStatus(String buildStatus) {
-        try {
-            this.buildStatus = StashBuildState.valueOf(buildStatus);
-        } catch (Exception e) {
+    public void setBuildStatus(Object buildStatus) {
+        if (buildStatus instanceof StashBuildState) {
+            this.buildStatus = (StashBuildState) buildStatus;
+        } else if (buildStatus instanceof String) {
+            try {
+                this.buildStatus = StashBuildState.valueOf((String) buildStatus);
+            } catch (Exception e) {
+                // ignore unknown or null values
+            }
+        } else {
             // ignore unknown or null values
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
@@ -48,6 +48,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -904,5 +905,41 @@ public class StashNotifierTest {
         NotificationResult notificationResult = notifyStash(204);
         verify(httpNotifier).send(any(), any(), any(), any());
         assertThat(notificationResult, equalTo(result));
+    }
+
+    @Test
+    public void setBuildStatus_string() {
+      sn.setBuildStatus("SUCCESSFUL");
+      assertThat(sn.getBuildStatus(), equalTo(StashBuildState.SUCCESSFUL));
+
+      sn.setBuildStatus("FAILED");
+      assertThat(sn.getBuildStatus(), equalTo(StashBuildState.FAILED));
+
+      sn.setBuildStatus("INPROGRESS");
+      assertThat(sn.getBuildStatus(), equalTo(StashBuildState.INPROGRESS));
+    }
+
+    @Test
+    public void setBuildStatus_stashBuildState() {
+      sn.setBuildStatus(StashBuildState.SUCCESSFUL);
+      assertThat(sn.getBuildStatus(), equalTo(StashBuildState.SUCCESSFUL));
+
+      sn.setBuildStatus(StashBuildState.FAILED);
+      assertThat(sn.getBuildStatus(), equalTo(StashBuildState.FAILED));
+
+      sn.setBuildStatus(StashBuildState.INPROGRESS);
+      assertThat(sn.getBuildStatus(), equalTo(StashBuildState.INPROGRESS));
+    }
+
+    @Test
+    public void setBuildStatus_null() {
+      sn.setBuildStatus(null);
+      assertThat(sn.getBuildStatus(), nullValue());
+
+      sn.setBuildStatus(StashBuildState.SUCCESSFUL);
+      assertThat(sn.getBuildStatus(), equalTo(StashBuildState.SUCCESSFUL));
+
+      sn.setBuildStatus(null);
+      assertThat(sn.getBuildStatus(), equalTo(StashBuildState.SUCCESSFUL));
     }
 }


### PR DESCRIPTION
Fix setBuildStatus to handle both String and StashBuildState arguments in a single method

This allows `@DataBoundSetter` to work for all cases and avoids the noisy stacktraces that were being flagged as an
issue in #266.

Method was changed to take a generic Object and distinguish between String and StashBuildState inside the method itself.

- Also added tests verifying the current behavior for all kinds of input.

Resolves:
- https://issues.jenkins.io/browse/JENKINS-64637
- https://github.com/jenkinsci/stashnotifier-plugin/issues/266

Checklist:
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue