### PR TITLE
added buildUrl property for overriding the url used for the build / run

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,7 @@ def notifyBitbucket(String state) {
             ignoreUnverifiedSSLPeer: true,
             buildStatus: state,
             buildName: 'Performance Testing',
+            buildUrl: 'https://my.company.intranet/bitbucket/custom-build-url',
             includeBuildNumberInKey: false,
             prependParentProjectKey: false,
             projectKey: '',

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -136,6 +136,12 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
     private String buildName;
 
     /**
+     * specify a build url to be included in the Bitbucket notification.
+     * If null, the usual url of the build will be used.
+     */
+    private String buildUrl;
+
+    /**
      * if true, the build number is included in the Bitbucket notification.
      */
     private boolean includeBuildNumberInKey;
@@ -182,6 +188,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             String commitSha1,
             String buildStatus,
             String buildName,
+            String buildUrl,
             boolean includeBuildNumberInKey,
             String projectKey,
             boolean prependParentProjectKey,
@@ -196,6 +203,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         setCommitSha1(commitSha1);
         setBuildStatus(buildStatus);
         setBuildName(buildName);
+        setBuildUrl(buildUrl);
         setIncludeBuildNumberInKey(includeBuildNumberInKey);
         setProjectKey(projectKey);
         setPrependParentProjectKey(prependParentProjectKey);
@@ -270,6 +278,15 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
     @DataBoundSetter
     public void setBuildName(String buildName) {
         this.buildName = buildName;
+    }
+
+    public String getBuildUrl() {
+        return buildUrl;
+    }
+
+    @DataBoundSetter
+    public void setBuildUrl(String buildUrl) {
+        this.buildUrl = buildUrl;
     }
 
     public boolean isIncludeBuildNumberInKey() {
@@ -888,7 +905,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
      * or the current build state else.
      *
      * @param currentBuildStatus the state of the current build
-     * @return the selected build state
+     * @return the current build status
      */
     protected StashBuildState getPushedBuildStatus(StashBuildState currentBuildStatus) {
         if (buildStatus != null) {
@@ -998,7 +1015,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         json.put("key", abbreviate(getBuildKey(run, listener), MAX_FIELD_LENGTH));
         json.put("name", abbreviate(getBuildName(run), MAX_FIELD_LENGTH));
         json.put("description", abbreviate(getBuildDescription(run, state), MAX_FIELD_LENGTH));
-        json.put("url", abbreviate(DisplayURLProvider.get().getRunURL(run), MAX_URL_FIELD_LENGTH));
+        json.put("url", abbreviate(getBuildUrl(run), MAX_URL_FIELD_LENGTH));
         return json;
     }
 
@@ -1081,13 +1098,28 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
      * or get the build name from the {@link Run}.
      *
      * @param run the run to notify Bitbucket of
-     * @return the selected build state
+     * @return the name of the run
      */
     protected String getBuildName(final Run<?, ?> run) {
         if (buildName != null && buildName.trim().length() > 0) {
             return buildName;
         } else {
             return run.getFullDisplayName();
+        }
+    }
+
+    /**
+     * Returns the build url to be pushed. This will select the specifically overwritten build url
+     * or get the build url from the {@link DisplayURLProvider}.
+     *
+     * @param run the run to notify Bitbucket of
+     * @return the url of the run
+     */
+    protected String getBuildUrl(final Run<?, ?> run) {
+        if (buildUrl != null && buildUrl.trim().length() > 0) {
+            return buildUrl;
+        } else {
+            return DisplayURLProvider.get().getRunURL(run);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -1116,7 +1116,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
      * @return the url of the run
      */
     protected String getBuildUrl(final Run<?, ?> run) {
-        if (buildUrl != null && buildUrl.trim().length() > 0) {
+        if (buildUrl != null && !buildUrl.trim().isEmpty()) {
             return buildUrl;
         } else {
             return DisplayURLProvider.get().getRunURL(run);


### PR DESCRIPTION
This pull request allows overriding the url used for the build / run. This is useful in pipeline builds where you might notify bitbucket about a particular stage, where the url should go directly to the logs of that stage, rather than the top level pipeline. A new prop `buildUrl` allows you to override what is used, otherwise the default url that comes from `DisplayURLProvider` is used. 

See feature request for more info - https://github.com/jenkinsci/stashnotifier-plugin/issues/302

- [ x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x ] Ensure that the pull request title represents the desired changelog entry
- [ x ] Please describe what you did
- [ x ] Link to relevant issues in GitHub or Jira
- [ x ] Link to relevant pull requests, esp. upstream and downstream changes
- [ x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
