### PR TITLE
[JENKINS-35551] Upgrade to Credentials v2

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
@@ -11,12 +11,15 @@ import org.acegisecurity.Authentication;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.kohsuke.stapler.*;
+import org.kohsuke.stapler.RequestImpl;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.TokenList;
+import org.kohsuke.stapler.WebApp;
+import org.mockito.MockedStatic;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
-import org.mockito.MockedStatic;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -109,7 +112,7 @@ public class DescriptorImplTest {
         when(jenkins.hasPermission(Item.CONFIGURE)).thenReturn(false);
 
         //when
-        ListBoxModel listBoxModel = desc.doFillCredentialsIdItems(null);
+        ListBoxModel listBoxModel = desc.doFillCredentialsIdItems(null, "dummyId");
 
         //then
         assertThat(listBoxModel, is(not(nullValue())));
@@ -123,7 +126,7 @@ public class DescriptorImplTest {
         when(jenkins.hasPermission(Item.CONFIGURE)).thenReturn(false);
 
         //when
-        ListBoxModel listBoxModel = desc.doFillCredentialsIdItems(project);
+        ListBoxModel listBoxModel = desc.doFillCredentialsIdItems(project, "dummyId");
 
         //then
         assertThat(listBoxModel, is(not(nullValue())));
@@ -134,15 +137,16 @@ public class DescriptorImplTest {
         //given
         Item project = mock(Item.class);
         when(project.hasPermission(Item.CONFIGURE)).thenReturn(true);
-        when(CredentialsProvider.lookupCredentials(
+        when(CredentialsProvider.listCredentials(
                 any(),
                 any(Item.class),
                 any(Authentication.class),
-                anyList()
-        )).thenReturn(new ArrayList<>());
+                anyList(),
+                any()
+        )).thenReturn(new ListBoxModel());
 
         //when
-        ListBoxModel listBoxModel = desc.doFillCredentialsIdItems(project);
+        ListBoxModel listBoxModel = desc.doFillCredentialsIdItems(project, "dummyId");
 
         //then
         assertThat(listBoxModel, is(not(nullValue())));


### PR DESCRIPTION
A first effort of Credentials v2 (#138, [JENKINS-35551](https://issues.jenkins-ci.org/browse/JENKINS-35551)).

I'm not very familiar with the API, most of it is based on the credentials docs and the linked issues. I'd appreciate someone with experience having a look at it – even more as it's security related.


------------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
