### PR TITLE
Use logger instead of build log

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/DefaultApacheHttpNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/DefaultApacheHttpNotifier.java
@@ -75,12 +75,11 @@ class DefaultApacheHttpNotifier implements HttpNotifier {
             final JSONObject payload,
             final Credentials credentials,
             @NonNull NotificationContext context) throws AuthenticationException {
-        PrintStream logger = context.getLogger();
         HttpPost req = new HttpPost(uri.toString());
 
         if (credentials != null) {
             if (credentials instanceof UsernamePasswordCredentials) {
-                logger.println("createRequest - UsernamePasswordCredentials");
+                LOGGER.debug("createRequest - UsernamePasswordCredentials");
                 req.addHeader(new BasicScheme().authenticate(
                         new org.apache.http.auth.UsernamePasswordCredentials(
                                 ((UsernamePasswordCredentials)credentials).getUsername(),
@@ -89,7 +88,7 @@ class DefaultApacheHttpNotifier implements HttpNotifier {
                         null));
             }
             else if (credentials instanceof StringCredentials) {
-                logger.println("createRequest - StringCredentials/secret text");
+                LOGGER.debug("createRequest - StringCredentials/secret text");
                 req.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + ((StringCredentials)credentials).getSecret().getPlainText());
             } 
             else {


### PR DESCRIPTION
Messages like _"createRequest - UsernamePasswordCredentials"_ are written to the build log. This PR moves them to a logger instead.

The messages are still around for debugging purpose, but aren't included in the build log anymore.

--------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
