### PR TITLE
Fix "Invalid cookie header" warnings

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/DefaultApacheHttpNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/DefaultApacheHttpNotifier.java
@@ -12,6 +12,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.AuthenticationException;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.config.Registry;
@@ -109,7 +110,8 @@ class DefaultApacheHttpNotifier implements HttpNotifier {
         RequestConfig.Builder requestBuilder = RequestConfig.custom()
                 .setSocketTimeout(timeoutInMilliseconds)
                 .setConnectTimeout(timeoutInMilliseconds)
-                .setConnectionRequestTimeout(timeoutInMilliseconds);
+                .setConnectionRequestTimeout(timeoutInMilliseconds)
+                .setCookieSpec(CookieSpecs.STANDARD);
 
         HttpClientBuilder clientBuilder = HttpClients.custom();
         clientBuilder.setDefaultRequestConfig(requestBuilder.build());

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -50,6 +50,7 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.AuthenticationException;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.config.Registry;
@@ -530,7 +531,8 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         RequestConfig.Builder requestBuilder = RequestConfig.custom()
                                             .setSocketTimeout(timeoutInMilliseconds)
                                             .setConnectTimeout(timeoutInMilliseconds)
-                                            .setConnectionRequestTimeout(timeoutInMilliseconds);
+                                            .setConnectionRequestTimeout(timeoutInMilliseconds)
+                                            .setCookieSpec(CookieSpecs.STANDARD);
 
         HttpClientBuilder clientBuilder = HttpClients.custom();
         clientBuilder.setDefaultRequestConfig(requestBuilder.build());


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Each status update sent to Bitbucket issues a warning in the Jenkins log:

> Invalid cookie header: "Set-Cookie: […]". Invalid 'expires' attribute: […]

This PR fixes the issue.

### Testing done

Verified on a Jenkins instance.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
