### PR TITLE
Modernize Tooling and Jenkins to 2.387.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.51</version>
+        <version>4.72</version>
         <relativePath />
     </parent>
     <packaging>hpi</packaging>
@@ -11,7 +11,7 @@
         <revision>1</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.346.3</jenkins.version>
+        <jenkins.version>2.387.3</jenkins.version>
         <hpi.compatibleSinceVersion>1.9</hpi.compatibleSinceVersion>
     </properties>
     <artifactId>stashNotifier</artifactId>
@@ -80,8 +80,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.346.x</artifactId>
-                <version>1763.v092b_8980a_f5e</version>
+                <artifactId>bom-2.387.x</artifactId>
+                <version>2329.v078520e55c19</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -119,7 +119,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
@@ -31,6 +31,7 @@ import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -80,11 +81,11 @@ public class StashNotifierTest {
     private static MockedStatic<HttpClientBuilder> mockedHttpClientBuilder;
     private static MockedStatic<DisplayURLProvider> mockedDisplayURLProvider;
 
-    private static StashNotifier buildStashNotifier(String stashBaseUrl) {
+    private StashNotifier buildStashNotifier(String stashBaseUrl) {
         return buildStashNotifier(stashBaseUrl, false, false);
     }
 
-    private static StashNotifier buildStashNotifier(String stashBaseUrl,
+    private StashNotifier buildStashNotifier(String stashBaseUrl,
                                             boolean disableInprogressNotification,
                                             boolean considerUnstableAsSuccess) {
         StashNotifier notifier = new StashNotifier(
@@ -106,7 +107,7 @@ public class StashNotifierTest {
         return notifier;
     }
 
-    private static StashNotifier sn;
+    private StashNotifier sn;
     private static BuildListener buildListener;
     private static AbstractBuild<?, ?> build;
     private static Run<?, ?> run;
@@ -177,7 +178,10 @@ public class StashNotifierTest {
                 anyList()
         )).thenReturn(new ArrayList<>());
         when(httpNotifierSelector.select(any())).thenReturn(httpNotifier);
+    }
 
+    @Before
+    public void setup() {
         sn = buildStashNotifier("http://localhost");
     }
 


### PR DESCRIPTION
Hi!

This PR upgrades to the most recent tooling and the currently recommended Jenkins baseline version.

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePlugin