### PR TITLE
Add plugin developer team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jenkinsci/stashnotifier-plugin-developers


### PR DESCRIPTION
This uses GitHub's CODEOWNERS feature to automatically assign reviewers to pull requests based on ownership. Newly generated plugins get this file by default.

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.github.AddTeamToCodeowners