### PR TITLE
Modernize to Jenkins 2.401.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,8 +80,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2516.v113cb_3d00317</version>
+                <artifactId>bom-2.401.x</artifactId>
+                <version>2612.v3d6a_2128c0ef</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <revision>1</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.version>2.401.3</jenkins.version>
         <hpi.compatibleSinceVersion>1.9</hpi.compatibleSinceVersion>
     </properties>
     <artifactId>stashNotifier</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -76,7 +76,7 @@ import org.kohsuke.stapler.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.io.PrintStream;

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifierDefault.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifierDefault.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.stashNotifier;
 
-import javax.inject.Qualifier;
+import jakarta.inject.Qualifier;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifierModule.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifierModule.java
@@ -7,8 +7,8 @@ import hudson.ExtensionList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
 import java.util.List;
 
 @Extension

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
@@ -137,10 +137,10 @@ public class DescriptorImplTest {
         //given
         Item project = mock(Item.class);
         when(project.hasPermission(Item.CONFIGURE)).thenReturn(true);
-        when(CredentialsProvider.listCredentials(
+        when(CredentialsProvider.listCredentialsInItem(
                 any(),
                 any(Item.class),
-                any(Authentication.class),
+                any(org.springframework.security.core.Authentication.class),
                 anyList(),
                 any()
         )).thenReturn(new ListBoxModel());


### PR DESCRIPTION
Hi!

This PR aims to modernize tooling and move this plugin to the [recommended](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) Jenkins baseline version.

2.401.2 was the [first version to include Guice 6.x](https://www.jenkins.io/changelog-stable/#v2.401.2), which supports `jakarta.inject`.

## Testing done
Ran `mvn clean verify`.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

Refs: sghill-rewrite/campaigns#1 sghill-rewrite/campaigns#2

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePlugin