### PR TITLE
#234: Do not require a workspace to notify Bitbucket

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -26,6 +26,7 @@ import com.google.inject.Injector;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.ProxyConfiguration;
 import hudson.model.*;
@@ -362,25 +363,28 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
     }
 
     @Override
+    public boolean requiresWorkspace() {
+        return false;
+    }
+
+    @Override
     public boolean perform(
             AbstractBuild<?, ?> build,
             Launcher launcher,
             BuildListener listener) {
-        return perform(build, null, listener, disableInprogressNotification);
+        return perform(build, listener, disableInprogressNotification);
     }
 
     @Override
     public void perform(@NonNull Run<?, ?> run,
-                        @NonNull FilePath workspace,
-                        @NonNull Launcher launcher,
+                        @NonNull EnvVars env,
                         @NonNull TaskListener listener) {
-        if (!perform(run, workspace, listener, false)) {
+        if (!perform(run, listener, false)) {
             run.setResult(Result.FAILURE);
         }
     }
 
     private boolean perform(Run<?, ?> run,
-                            FilePath workspace,
                             TaskListener listener,
                             boolean disableInProgress) {
         StashBuildState state;

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
@@ -111,7 +111,6 @@ public class StashNotifierTest {
     private static BuildListener buildListener;
     private static AbstractBuild<?, ?> build;
     private static Run<?, ?> run;
-    private static FilePath workspace;
 
     @BeforeClass
     public static void setUp() throws Exception {
@@ -131,7 +130,6 @@ public class StashNotifierTest {
         when(file.getPath()).thenReturn("/tmp/fake/path");
         FilePath filePath = new FilePath(file);
         when(project.getSomeWorkspace()).thenReturn(filePath);
-        workspace = project.getSomeWorkspace();
         EnvVars environment = mock(EnvVars.class);
         PrintStream logger = System.out;
         Secret secret = mock(Secret.class);
@@ -295,7 +293,7 @@ public class StashNotifierTest {
         Launcher launcher = test_perform(result, logger, notificationResult, hashes);
 
         //when
-        sn.perform(build, workspace, launcher, buildListener);
+        sn.perform(build, launcher, buildListener);
 
         //then
         assertThat(build.getResult(), is(result));
@@ -483,7 +481,7 @@ public class StashNotifierTest {
         doReturn(new ArrayList<String>()).when(sn).lookupCommitSha1s(eq(build), eq(null), eq(buildListener));
 
         //when
-        sn.perform(build, workspace, mock(Launcher.class), buildListener);
+        sn.perform(build, mock(Launcher.class), buildListener);
 
         //then
         verify(sn, never()).notifyStash(


### PR DESCRIPTION
Implements #234

Historically, the stashNotifier plugin required a workspace context in order to perform the plugin task, albeit not making use of the workspace in any way.

This change removes the implementation of the `perform` method requiring a workspace and replaces it with the one not requiring a workspace.

### Testing done

#### Regular pipeline (without workspace)
Created a simple Pipeline checking out a Git repository on a specific node with the pipeline not requiring one; notifications work as intended:

```groovy
pipeline {
    agent none

    stages {
        stage('Hello') {
            agent {
                label 'linux'
            }

            steps {
                git branch: 'foo', changelog: false, credentialsId: '****', poll: false, url: '****/jenkins_bitbucket_notifier.git'
                echo 'Hello World'
            }
        }
    }

    post {
        always {
            notifyBitbucket()
        }
    }
}
```

#### Regular pipeline (with workspace)
Created a simple Pipeline that allocates a node top-level; notifications work as intended/before:

```groovy
pipeline {
    agent {
        label 'linux'
    }

    stages {
        stage('Hello') {
            steps {
                git branch: 'foo', changelog: false, credentialsId: '****', poll: false, url: '****/jenkins_bitbucket_notifier.git'
                echo 'Hello World'
            }
        }
    }

    post {
        always {
            notifyBitbucket()
        }
    }
}
```

#### Regular pipeline (with node(null) in post)
```groovy
pipeline {
    agent none

    stages {
        stage('Hello') {
            agent {
                label 'linux'
            }

            steps {
                git branch: 'foo', changelog: false, credentialsId: '****', poll: false, url: '****/jenkins_bitbucket_notifier.git'
                echo 'Hello World'
            }
        }
    }

    post {
        always {
            script {
                node(null) {
                    notifyBitbucket()
                }
            }
        }
    }
}
```

#### Freestyle job
Triggered a freestyle build with a post-build action to notify Bitbucket -> still works as intended (pre- and post-build notifications are sent).

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue