### PR TITLE
Add Example Logging Http Notifier

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/example/LoggingHttpNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/example/LoggingHttpNotifier.java
@@ -1,0 +1,41 @@
+package org.jenkinsci.plugins.stashNotifier.example;
+
+import java.io.PrintStream;
+import java.net.URI;
+
+import org.jenkinsci.plugins.stashNotifier.HttpNotifier;
+import org.jenkinsci.plugins.stashNotifier.NotificationContext;
+import org.jenkinsci.plugins.stashNotifier.NotificationResult;
+import org.jenkinsci.plugins.stashNotifier.NotificationSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.cloudbees.plugins.credentials.Credentials;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import net.sf.json.JSONObject;
+
+/**
+ * Included as an example to demonstrate how alternative notifiers work.
+ * Set the system property <code>-Dorg.jenkinsci.plugins.stashNotifier.HttpNotifierSelector.className=org.jenkinsci.plugins.stashNotifier.example.LoggingHttpNotifierSelector<code>
+ * to tell the system to choose this implementation.
+ */
+class LoggingHttpNotifier implements HttpNotifier {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingHttpNotifier.class);
+
+    @Override
+    public @NonNull NotificationResult send(@NonNull URI uri, @NonNull JSONObject payload, @NonNull NotificationSettings settings, @NonNull NotificationContext context) {
+        Credentials creds = settings.getCredentials();
+        String runId = context.getRunId();
+        PrintStream buildLog = context.getLogger();
+        String target = uri == null ? "(undefined)" : uri.toASCIIString();
+        buildLog.println("[stash-notifier] would have notified " + target + " with " + payload);
+        if (creds != null) {
+            Class<?> credsClass = creds.getClass();
+            LOGGER.info("{} would have used {} to notify {} with payload {}", runId, credsClass.getSimpleName(), target, payload);
+        } else {
+            LOGGER.info("{} would have notified {} with payload {}", runId, target, payload);
+        }
+        return NotificationResult.newSuccess();
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/example/LoggingHttpNotifierSelector.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/example/LoggingHttpNotifierSelector.java
@@ -1,0 +1,22 @@
+package org.jenkinsci.plugins.stashNotifier.example;
+
+import org.jenkinsci.plugins.stashNotifier.HttpNotifier;
+import org.jenkinsci.plugins.stashNotifier.HttpNotifierSelector;
+import org.jenkinsci.plugins.stashNotifier.SelectionContext;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * This is an example alternative way of selecting a {@link HttpNotifier}.
+ */
+class LoggingHttpNotifierSelector implements HttpNotifierSelector {
+
+    /**
+     * @param context unused
+     * @return {@link LoggingHttpNotifier}
+     */
+    @Override
+    public @NonNull HttpNotifier select(@NonNull SelectionContext context) {
+        return new LoggingHttpNotifier();
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/example/LoggingNotifierModule.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/example/LoggingNotifierModule.java
@@ -1,0 +1,15 @@
+package org.jenkinsci.plugins.stashNotifier.example;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import hudson.Extension;
+import jakarta.inject.Singleton;
+
+@Extension
+public class LoggingNotifierModule extends AbstractModule {
+    @Provides
+    @Singleton
+    LoggingHttpNotifierSelector providesLoggingNotifierSelector() {
+        return new LoggingHttpNotifierSelector();
+    }
+}


### PR DESCRIPTION
This demonstrates how to use an alternative `HttpNotifier` and makes it easier to perform exploratory testing. By setting the system property `org.jenkinsci.plugins.stashNotifier.HttpNotifierSelector.className=org.jenkinsci.plugins.stashNotifier.example.LoggingHttpNotifierSelector`, a server can be run that uses the example `HttpNotifier`.

Creating a build with a post-build action to Notify Bitbucket Instance will show this custom message in the server logs, and build's console text.

<!-- Please describe your pull request here. -->

Introduced to simplify testing for #425.

### Testing done

I ran `mvn -Dorg.jenkinsci.plugins.stashNotifier.HttpNotifierSelector.className=org.jenkinsci.plugins.stashNotifier.example.LoggingHttpNotifierSelector hpi:run`, created a job that uses the plugin, and verified the log messages were as expected.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
