### PR TITLE
Fix Required Builds merge check by switching to repo-scoped Bitbucket…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactory.java
@@ -13,4 +13,10 @@ public class BuildStatusUriFactory {
         String uri = String.join("/", tidyBase, "rest/build-status/1.0/commits", commit);
         return URI.create(uri);
     }
+
+    public static URI create(String baseUri, String projectKey, String repoSlug, String commit) {
+        String tidyBase = StringUtils.removeEnd(baseUri, "/");
+        String uri = String.join("/", tidyBase, "rest/api/latest/projects", projectKey, "repos", repoSlug, "commits", commit, "builds");
+        return URI.create(uri);
+    }
 }

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/DefaultApacheHttpNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/DefaultApacheHttpNotifier.java
@@ -60,10 +60,11 @@ class DefaultApacheHttpNotifier implements HttpNotifier {
         try (CloseableHttpClient client = getHttpClient(logger, uri, settings.isIgnoreUnverifiedSSL())) {
             HttpPost req = createRequest(uri, payload, settings.getCredentials(), context);
             HttpResponse res = client.execute(req);
-            if (res.getStatusLine().getStatusCode() != 204) {
-                return NotificationResult.newFailure(EntityUtils.toString(res.getEntity()));
-            } else {
+            int statusCode = res.getStatusLine().getStatusCode();
+            if (statusCode >= 200 && statusCode < 300) {
                 return NotificationResult.newSuccess();
+            } else {
+                return NotificationResult.newFailure(EntityUtils.toString(res.getEntity()));
             }
         } catch (Exception e) {
             LOGGER.warn("{} failed to send {} to Bitbucket Server at {}", context.getRunId(), payload, uri, e);

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -862,7 +862,15 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         Credentials stringCredentials
                 = getCredentials(StringCredentials.class, run.getParent());
 
-        URI uri = BuildStatusUriFactory.create(stashURL, commitSha1);
+        String[] repoInfo = resolveBitbucketRepo(run, logger);
+        URI uri;
+        if (repoInfo != null) {
+            uri = BuildStatusUriFactory.create(stashURL, repoInfo[0], repoInfo[1], commitSha1);
+            logger.println("Using repo-scoped builds API: " + uri);
+        } else {
+            uri = BuildStatusUriFactory.create(stashURL, commitSha1);
+            logger.println("Using legacy build-status API: " + uri);
+        }
         NotificationSettings settings = new NotificationSettings(
                 ignoreUnverifiedSSLPeer || getDescriptor().isIgnoreUnverifiedSsl(),
                 stringCredentials != null ? stringCredentials : usernamePasswordCredentials
@@ -1023,11 +1031,13 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             TaskListener listener) {
 
         JSONObject json = new JSONObject();
+        String buildKey = abbreviate(getBuildKey(run, listener), MAX_FIELD_LENGTH);
         json.put("state", state.name());
-        json.put("key", abbreviate(getBuildKey(run, listener), MAX_FIELD_LENGTH));
+        json.put("key", buildKey);
         json.put("name", abbreviate(getBuildName(run), MAX_FIELD_LENGTH));
         json.put("description", abbreviate(getBuildDescription(run, state), MAX_FIELD_LENGTH));
         json.put("url", abbreviate(getBuildUrl(run), MAX_URL_FIELD_LENGTH));
+        json.put("parent", buildKey);
         return json;
     }
 
@@ -1107,6 +1117,87 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
     private static String idOf(Run<?, ?> run) {
         return run != null ? run.getExternalizableId() : "(absent run)";
+    }
+
+    /**
+     * Extracts the Bitbucket project key and repository slug from a Git remote URL.
+     * Supports common Bitbucket Server URL formats:
+     * <ul>
+     *   <li>HTTPS: {@code https://host/scm/PROJECT/repo.git}</li>
+     *   <li>SSH: {@code ssh://git@host:7999/PROJECT/repo.git}</li>
+     *   <li>SCP-style: {@code git@host:PROJECT/repo.git}</li>
+     *   <li>Personal repos: {@code https://host/scm/~user/repo.git}</li>
+     * </ul>
+     *
+     * @param remoteUrl the Git remote URL
+     * @return a two-element array [projectKey, repoSlug], or null if parsing fails
+     */
+    static String[] parseBitbucketRemoteUrl(String remoteUrl) {
+        if (remoteUrl == null || remoteUrl.isEmpty()) {
+            return null;
+        }
+
+        // Remove trailing .git
+        String url = remoteUrl.replaceAll("\\.git$", "");
+
+        // Handle SCP-style: git@host:PROJECT/repo
+        if (url.matches("^[^/]+@[^:]+:.+/.+$") && !url.startsWith("ssh://")) {
+            String path = url.substring(url.indexOf(':') + 1);
+            String[] parts = path.split("/");
+            if (parts.length >= 2) {
+                return new String[]{parts[parts.length - 2], parts[parts.length - 1]};
+            }
+            return null;
+        }
+
+        // Handle URL-style (https://, ssh://)
+        // Extract path and get last two segments
+        String path;
+        try {
+            URI uri = URI.create(url);
+            path = uri.getPath();
+        } catch (Exception e) {
+            return null;
+        }
+
+        if (path == null || path.isEmpty()) {
+            return null;
+        }
+
+        // Remove /scm/ prefix if present (Bitbucket Server HTTPS clone URLs use /scm/)
+        path = path.replaceFirst("^/scm/", "/");
+
+        // Remove leading slash and split
+        path = path.replaceFirst("^/", "");
+        String[] segments = path.split("/");
+        if (segments.length >= 2) {
+            return new String[]{segments[segments.length - 2], segments[segments.length - 1]};
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolves the Bitbucket project key and repository slug for the current build.
+     * Uses manually configured values if available, otherwise auto-detects from Git remote URL.
+     *
+     * @param run the current build run
+     * @param logger the logger for output
+     * @return a two-element array [projectKey, repoSlug], or null if not resolvable
+     */
+    private String[] resolveBitbucketRepo(Run<?, ?> run, PrintStream logger) {
+        for (BuildData buildData : run.getActions(BuildData.class)) {
+            for (String remoteUrl : buildData.getRemoteUrls()) {
+                String[] parsed = parseBitbucketRemoteUrl(remoteUrl);
+                if (parsed != null) {
+                    logger.println("Auto-detected Bitbucket project: " + parsed[0] + ", repo: " + parsed[1] + " from " + remoteUrl);
+                    return parsed;
+                }
+            }
+        }
+
+        logger.println("Could not determine Bitbucket project/repo - falling back to legacy build-status API");
+        return null;
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactoryTest.java
@@ -40,4 +40,28 @@ class BuildStatusUriFactoryTest {
         URI actual = BuildStatusUriFactory.create(baseUri, "25a4b3c9b494fc7ac65b80e3b0ecce63f235f20d");
         assertThat(actual, equalTo(expected));
     }
+
+    @Test
+    void shouldCreateRepoScopedUri() {
+        String baseUri = "http://localhost:12345";
+        URI expected = URI.create("http://localhost:12345/rest/api/latest/projects/PROJ/repos/my-repo/commits/abc123/builds");
+        URI actual = BuildStatusUriFactory.create(baseUri, "PROJ", "my-repo", "abc123");
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    void shouldCreateRepoScopedUriWithTrailingSlash() {
+        String baseUri = "http://localhost:12345/";
+        URI expected = URI.create("http://localhost:12345/rest/api/latest/projects/PROJ/repos/my-repo/commits/abc123/builds");
+        URI actual = BuildStatusUriFactory.create(baseUri, "PROJ", "my-repo", "abc123");
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    void shouldCreateRepoScopedUriWithBasePath() {
+        String baseUri = "http://localhost:12345/bitbucket";
+        URI expected = URI.create("http://localhost:12345/bitbucket/rest/api/latest/projects/PROJ/repos/my-repo/commits/25a4b3c9/builds");
+        URI actual = BuildStatusUriFactory.create(baseUri, "PROJ", "my-repo", "25a4b3c9");
+        assertThat(actual, equalTo(expected));
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactoryTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 class BuildStatusUriFactoryTest {
 
     @Test
-    void shouldHandleTrailingSlash() {
+    void shouldCreateLegacyUriWithTrailingSlash() {
         String baseUri = "http://localhost:12345/";
         URI expected = URI.create("http://localhost:12345/rest/build-status/1.0/commits/25a4b3c9b494fc7ac65b80e3b0ecce63f235f20d");
         URI actual = BuildStatusUriFactory.create(baseUri, "25a4b3c9b494fc7ac65b80e3b0ecce63f235f20d");
@@ -18,7 +18,7 @@ class BuildStatusUriFactoryTest {
     }
 
     @Test
-    void shouldHandleNoTrailingSlash() {
+    void shouldCreateLegacyUriWithNoTrailingSlash() {
         String baseUri = "http://localhost:12345";
         URI expected = URI.create("http://localhost:12345/rest/build-status/1.0/commits/25a4b3c9b494fc7ac65b80e3b0ecce63f235f20d");
         URI actual = BuildStatusUriFactory.create(baseUri, "25a4b3c9b494fc7ac65b80e3b0ecce63f235f20d");
@@ -26,7 +26,7 @@ class BuildStatusUriFactoryTest {
     }
 
     @Test
-    void shouldHandleBasePathTrailingSlash() {
+    void shouldCreateLegacyUriWithBasePathTrailingSlash() {
         String baseUri = "http://localhost:12345/some-path/";
         URI expected = URI.create("http://localhost:12345/some-path/rest/build-status/1.0/commits/25a4b3c9b494fc7ac65b80e3b0ecce63f235f20d");
         URI actual = BuildStatusUriFactory.create(baseUri, "25a4b3c9b494fc7ac65b80e3b0ecce63f235f20d");
@@ -34,7 +34,7 @@ class BuildStatusUriFactoryTest {
     }
 
     @Test
-    void shouldHandleBasePathNoTrailingSlash() {
+    void shouldCreateLegacyUriWithBasePathNoTrailingSlash() {
         String baseUri = "http://localhost:12345/some-path";
         URI expected = URI.create("http://localhost:12345/some-path/rest/build-status/1.0/commits/25a4b3c9b494fc7ac65b80e3b0ecce63f235f20d");
         URI actual = BuildStatusUriFactory.create(baseUri, "25a4b3c9b494fc7ac65b80e3b0ecce63f235f20d");

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/DefaultApacheHttpNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/DefaultApacheHttpNotifierTest.java
@@ -156,14 +156,32 @@ class DefaultApacheHttpNotifierTest {
     }
 
     @Test
-    void notifyStash_success() throws Exception {
+    void notifyStash_success204() throws Exception {
         NotificationResult notificationResult = notifyStash(204);
+        assertThat(notificationResult.indicatesSuccess, is(true));
+    }
+
+    @Test
+    void notifyStash_success200() throws Exception {
+        NotificationResult notificationResult = notifyStash(200);
+        assertThat(notificationResult.indicatesSuccess, is(true));
+    }
+
+    @Test
+    void notifyStash_success201() throws Exception {
+        NotificationResult notificationResult = notifyStash(201);
         assertThat(notificationResult.indicatesSuccess, is(true));
     }
 
     @Test
     void notifyStash_fail() throws Exception {
         NotificationResult notificationResult = notifyStash(400);
+        assertThat(notificationResult.indicatesSuccess, is(false));
+    }
+
+    @Test
+    void notifyStash_fail500() throws Exception {
+        NotificationResult notificationResult = notifyStash(500);
         assertThat(notificationResult.indicatesSuccess, is(false));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierTest.java
@@ -1014,4 +1014,49 @@ class StashNotifierTest {
       sn.setBuildStatus(null);
       assertThat(sn.getBuildStatus(), equalTo(StashBuildState.SUCCESSFUL));
     }
+
+    @Test
+    void parseBitbucketRemoteUrl_https_with_scm() {
+        String[] result = StashNotifier.parseBitbucketRemoteUrl("https://bitbucket.example.com/scm/PROJ/my-repo.git");
+        assertThat(result[0], equalTo("PROJ"));
+        assertThat(result[1], equalTo("my-repo"));
+    }
+
+    @Test
+    void parseBitbucketRemoteUrl_ssh() {
+        String[] result = StashNotifier.parseBitbucketRemoteUrl("ssh://git@bitbucket.example.com:7999/PROJ/my-repo.git");
+        assertThat(result[0], equalTo("PROJ"));
+        assertThat(result[1], equalTo("my-repo"));
+    }
+
+    @Test
+    void parseBitbucketRemoteUrl_scp_style() {
+        String[] result = StashNotifier.parseBitbucketRemoteUrl("git@bitbucket.example.com:PROJ/my-repo.git");
+        assertThat(result[0], equalTo("PROJ"));
+        assertThat(result[1], equalTo("my-repo"));
+    }
+
+    @Test
+    void parseBitbucketRemoteUrl_personal_repo() {
+        String[] result = StashNotifier.parseBitbucketRemoteUrl("https://bitbucket.example.com/scm/~username/my-repo.git");
+        assertThat(result[0], equalTo("~username"));
+        assertThat(result[1], equalTo("my-repo"));
+    }
+
+    @Test
+    void parseBitbucketRemoteUrl_no_dotgit_suffix() {
+        String[] result = StashNotifier.parseBitbucketRemoteUrl("https://bitbucket.example.com/scm/PROJ/repo");
+        assertThat(result[0], equalTo("PROJ"));
+        assertThat(result[1], equalTo("repo"));
+    }
+
+    @Test
+    void parseBitbucketRemoteUrl_null() {
+        assertThat(StashNotifier.parseBitbucketRemoteUrl(null), nullValue());
+    }
+
+    @Test
+    void parseBitbucketRemoteUrl_empty() {
+        assertThat(StashNotifier.parseBitbucketRemoteUrl(""), nullValue());
+    }
 }


### PR DESCRIPTION
Use repo-scoped Bitbucket builds API to fix Required Builds merge check

  The plugin currently uses the deprecated `/rest/build-status/1.0/commits/{sha}` endpoint,
  which does not work with Bitbucket's "Required Builds" merge check — builds appear on
  commits but are not recognized as satisfying merge requirements.

  This PR switches to the repo-scoped `/rest/api/latest/projects/{project}/repos/{repo}/commits/{sha}/builds`
  endpoint and adds the `parent` field to the payload. (requires read permissions)

  Changes:
  - New `BuildStatusUriFactory.create()` overload for repo-scoped API
  - Auto-detect project key and repo slug from Git remote URL
  - Add `parent` field to notification payload (required for Required Builds matching)
  - Accept HTTP 200-299 responses (new API returns 200, not 204)
  - Fall back to legacy API when project/repo cannot be determined

  ### Testing done

  - All existing 76 tests pass, new unit tests added for:
    - Repo-scoped URI construction
    - HTTP 200/201/204 success and 400/500 failure responses
    - Git remote URL parsing (HTTPS, SSH, SCP-style, personal repos)
  - Manual testing against Bitbucket Data Center with Required Builds merge check enabled

  ### Submitter checklist
  - [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
  - [x] Ensure that the pull request title represents the desired changelog entry
  - [x] Please describe what you did
  - [x] Link to relevant issues in GitHub or Jira — Fixes #290
  - [ ] Link to relevant pull requests, esp. upstream and downstream changes
  - [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed