### PR TITLE
feat: Add notifyBitbucketRequiredBuild()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,10 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>branch-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
             <type>jar</type>
         </dependency>

--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,27 @@ def notifyBitbucket(String state) {
 }
 ```
 
+### Bitbucket Required Builds
+
+Bitbucket Data Center 7.4 and newer provides a repository build status API used by
+the Required Builds merge check. Use `notifyBitbucketRequiredBuild` to send the
+additional build parent required by that check:
+
+```groovy
+notifyBitbucketRequiredBuild(
+        bitbucketProjectKey: 'PROJ',
+        repositorySlug: 'my-repository',
+        credentialsId: '00000000-1111-2222-3333-123456789abc',
+        stashServerBaseUrl: 'https://my.company.intranet/bitbucket')
+```
+
+`bitbucketProjectKey` and `repositorySlug` identify the repository in Bitbucket
+and are required. Both support token macros. All optional settings available on
+`notifyBitbucket` are also available on this step. The build key override is named
+`buildKey` on this step; it is equivalent to the legacy step's `projectKey`
+setting. For a multibranch Pipeline, the build parent is the full Jenkins path of
+the multibranch project without the branch name.
+
 In [Declarative Pipelines](https://jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline), where Jenkins sets `currentBuild.result = null` for `SUCCESS` builds, the current value can be modified via a `script` step, e.g.:
 
 ```groovy

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,6 @@ node {
 
     try {
         // Do stuff
-
         currentBuild.result = 'SUCCESS'     // Set result of currentBuild !Important!
     } catch(err) {
         currentBuild.result = 'FAILURE'     // Set result of currentBuild !Important!
@@ -130,27 +129,6 @@ def notifyBitbucket(String state) {
 }
 ```
 
-### Bitbucket Required Builds
-
-Bitbucket Data Center 7.4 and newer provides a repository build status API used by
-the Required Builds merge check. Use `notifyBitbucketRequiredBuild` to send the
-additional build parent required by that check:
-
-```groovy
-notifyBitbucketRequiredBuild(
-        bitbucketProjectKey: 'PROJ',
-        repositorySlug: 'my-repository',
-        credentialsId: '00000000-1111-2222-3333-123456789abc',
-        stashServerBaseUrl: 'https://my.company.intranet/bitbucket')
-```
-
-`bitbucketProjectKey` and `repositorySlug` identify the repository in Bitbucket
-and are required. Both support token macros. All optional settings available on
-`notifyBitbucket` are also available on this step. The build key override is named
-`buildKey` on this step; it is equivalent to the legacy step's `projectKey`
-setting. For a multibranch Pipeline, the build parent is the full Jenkins path of
-the multibranch project without the branch name.
-
 In [Declarative Pipelines](https://jenkins.io/doc/book/pipeline/syntax/#declarative-pipeline), where Jenkins sets `currentBuild.result = null` for `SUCCESS` builds, the current value can be modified via a `script` step, e.g.:
 
 ```groovy
@@ -174,6 +152,27 @@ pipeline {
     }
 }
 ```
+
+### Bitbucket Required Builds
+
+Bitbucket Data Center 7.4 and newer provides a repository build status API used by
+the Required Builds merge check. Use `notifyBitbucketRequiredBuild` to send the
+additional build parent required by that check:
+
+```groovy
+notifyBitbucketRequiredBuild(
+        bitbucketProjectKey: 'PROJ',
+        repositorySlug: 'my-repository',
+        credentialsId: '00000000-1111-2222-3333-123456789abc',
+        stashServerBaseUrl: 'https://my.company.intranet/bitbucket')
+```
+
+`bitbucketProjectKey` and `repositorySlug` identify the repository in Bitbucket
+and are required. Both support token macros. All optional settings available on
+`notifyBitbucket` are also available on this step. The build key override is named
+`buildKey` on this step; it is equivalent to the existing `notifyBitbucket`
+step's `projectKey` setting. For a multibranch Pipeline, the build parent is the
+full Jenkins path of the multibranch project without the branch name.
 
 ### Note on credentials
 

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactory.java
@@ -1,8 +1,12 @@
 package org.jenkinsci.plugins.stashNotifier;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
 
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class BuildStatusUriFactory {
     private BuildStatusUriFactory() {
@@ -12,5 +16,25 @@ public class BuildStatusUriFactory {
         String tidyBase = StringUtils.removeEnd(baseUri, "/");
         String uri = String.join("/", tidyBase, "rest/build-status/1.0/commits", commit);
         return URI.create(uri);
+    }
+
+    public static URI createRequiredBuild(String baseUri, String projectKey, String repositorySlug, String commit) {
+        try {
+            URIBuilder builder = new URIBuilder(StringUtils.removeEnd(baseUri, "/"));
+            List<String> pathSegments = new ArrayList<>(builder.getPathSegments());
+            pathSegments.add("rest");
+            pathSegments.add("api");
+            pathSegments.add("latest");
+            pathSegments.add("projects");
+            pathSegments.add(projectKey);
+            pathSegments.add("repos");
+            pathSegments.add(repositorySlug);
+            pathSegments.add("commits");
+            pathSegments.add(commit);
+            pathSegments.add("builds");
+            return builder.setPathSegments(pathSegments).build();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Unable to create Required Builds URI", e);
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifier.java
@@ -115,5 +115,10 @@ public class RequiredBuildNotifier extends StashNotifier {
         public String getDisplayName() {
             return "Notify Bitbucket Required Build";
         }
+
+        @Override
+        public String getGlobalConfigPage() {
+            return null;
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifier.java
@@ -1,0 +1,119 @@
+package org.jenkinsci.plugins.stashNotifier;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.ItemGroup;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Publisher;
+import jenkins.branch.MultiBranchProject;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Notifies Bitbucket using the repository build status API required by the
+ * Required Builds merge check.
+ */
+public class RequiredBuildNotifier extends StashNotifier {
+    private final String bitbucketProjectKey;
+    private final String repositorySlug;
+
+    @DataBoundConstructor
+    public RequiredBuildNotifier(String bitbucketProjectKey, String repositorySlug) {
+        this.bitbucketProjectKey = bitbucketProjectKey;
+        this.repositorySlug = repositorySlug;
+    }
+
+    public String getBitbucketProjectKey() {
+        return bitbucketProjectKey;
+    }
+
+    public String getRepositorySlug() {
+        return repositorySlug;
+    }
+
+    public String getBuildKey() {
+        return super.getProjectKey();
+    }
+
+    @DataBoundSetter
+    public void setBuildKey(String buildKey) {
+        super.setProjectKey(buildKey);
+    }
+
+    @Override
+    public void setProjectKey(String projectKey) {
+        super.setProjectKey(projectKey);
+    }
+
+    @Override
+    protected URI createBuildStatusUri(
+            String stashURL,
+            String commitSha1,
+            Run<?, ?> run,
+            TaskListener listener) {
+        try {
+            String expandedProjectKey = expandValue(run, listener, bitbucketProjectKey);
+            String expandedRepositorySlug = expandValue(run, listener, repositorySlug);
+            if (StringUtils.isBlank(expandedProjectKey)) {
+                throw new IllegalArgumentException("Bitbucket project key must not be empty");
+            }
+            if (StringUtils.isBlank(expandedRepositorySlug)) {
+                throw new IllegalArgumentException("Bitbucket repository slug must not be empty");
+            }
+            return BuildStatusUriFactory.createRequiredBuild(
+                    stashURL,
+                    expandedProjectKey,
+                    expandedRepositorySlug,
+                    commitSha1);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalArgumentException("Unable to expand Bitbucket repository coordinates", e);
+        } catch (IOException | MacroEvaluationException e) {
+            throw new IllegalArgumentException("Unable to expand Bitbucket repository coordinates", e);
+        }
+    }
+
+    @Override
+    protected JSONObject createNotificationPayload(
+            Run<?, ?> run,
+            StashBuildState state,
+            TaskListener listener) {
+        JSONObject payload = super.createNotificationPayload(run, state, listener);
+        payload.put("parent", abbreviate(getBuildParent(run), MAX_FIELD_LENGTH));
+        return payload;
+    }
+
+    String getBuildParent(Run<?, ?> run) {
+        ItemGroup<?> parent = run.getParent().getParent();
+        if (parent instanceof MultiBranchProject<?, ?>) {
+            return parent.getFullName();
+        }
+        return run.getParent().getFullName();
+    }
+
+    @Symbol("notifyBitbucketRequiredBuild")
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+        @SuppressWarnings("rawtypes")
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return "Notify Bitbucket Required Build";
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -532,7 +532,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
      */
     @Deprecated
     protected CloseableHttpClient getHttpClient(PrintStream logger, Run<?, ?> run, String stashServer) throws Exception {
-        DescriptorImpl globalSettings = getDescriptor();
+        DescriptorImpl globalSettings = getGlobalDescriptor();
 
         final int timeoutInMilliseconds = 60_000;
 
@@ -638,10 +638,8 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         }
     }
 
-    @Override
-    public DescriptorImpl getDescriptor() {
-        // see Descriptor javadoc for more about what a descriptor is.
-        return (DescriptorImpl) super.getDescriptor();
+    protected DescriptorImpl getGlobalDescriptor() {
+        return Jenkins.get().getDescriptorByType(DescriptorImpl.class);
     }
 
     @Symbol({"notifyBitbucket", "notifyStash"})
@@ -862,9 +860,16 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         Credentials stringCredentials
                 = getCredentials(StringCredentials.class, run.getParent());
 
-        URI uri = BuildStatusUriFactory.create(stashURL, commitSha1);
+        URI uri;
+        try {
+            uri = createBuildStatusUri(stashURL, commitSha1, run, listener);
+        } catch (RuntimeException e) {
+            logger.println("Unable to create Bitbucket build status URL: " + e.getMessage());
+            LOGGER.error("{} unable to create Bitbucket build status URL", idOf(run), e);
+            return NotificationResult.newFailure(e.getMessage());
+        }
         NotificationSettings settings = new NotificationSettings(
-                ignoreUnverifiedSSLPeer || getDescriptor().isIgnoreUnverifiedSsl(),
+                ignoreUnverifiedSSLPeer || getGlobalDescriptor().isIgnoreUnverifiedSsl(),
                 stringCredentials != null ? stringCredentials : usernamePasswordCredentials
         );
         NotificationContext context = new NotificationContext(
@@ -873,6 +878,14 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         );
         HttpNotifier notifier = getHttpNotifierSelector().select(new SelectionContext(run.getParent().getFullName()));
         return notifier.send(uri, payload, settings, context);
+    }
+
+    protected URI createBuildStatusUri(
+            String stashURL,
+            String commitSha1,
+            Run<?, ?> run,
+            TaskListener listener) {
+        return BuildStatusUriFactory.create(stashURL, commitSha1);
     }
 
     /**
@@ -898,7 +911,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         }
 
         if (credentials == null) {
-            DescriptorImpl descriptor = getDescriptor();
+            DescriptorImpl descriptor = getGlobalDescriptor();
             if (StringUtils.isBlank(credentialsId) && descriptor != null) {
                 credentialsId = descriptor.getCredentialsId();
             }
@@ -971,7 +984,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
     private String expandStashURL(Run<?, ?> run, final TaskListener listener) {
         String url = stashServerBaseUrl;
-        DescriptorImpl descriptor = getDescriptor();
+        DescriptorImpl descriptor = getGlobalDescriptor();
         if (url == null || url.isEmpty()) {
             url = descriptor.getStashRootUrl();
         }
@@ -989,6 +1002,14 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             LOGGER.error("{} unable to expand Bitbucket server URL", idOf(run), ex);
         }
         return url;
+    }
+
+    protected String expandValue(Run<?, ?> run, TaskListener listener, String value)
+            throws IOException, InterruptedException, MacroEvaluationException {
+        if (run instanceof AbstractBuild<?, ?>) {
+            return TokenMacro.expandAll((AbstractBuild<?, ?>) run, listener, value);
+        }
+        return TokenMacro.expandAll(run, new FilePath(run.getRootDir()), listener, value);
     }
 
     /**
@@ -1017,7 +1038,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
      * @param run the run to notify Bitbucket of
      * @return JSON body for POST to Bitbucket build API
      */
-    private JSONObject createNotificationPayload(
+    protected JSONObject createNotificationPayload(
             final Run<?, ?> run,
             final StashBuildState state,
             TaskListener listener) {
@@ -1031,7 +1052,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         return json;
     }
 
-    private static String abbreviate(String text, int maxWidth) {
+    protected static String abbreviate(String text, int maxWidth) {
         if (text == null) {
             return null;
         }
@@ -1055,7 +1076,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
         key.append(run.getParent().getName());
         if (includeBuildNumberInKey
-                || getDescriptor().isIncludeBuildNumberInKey()) {
+                || getGlobalDescriptor().isIncludeBuildNumberInKey()) {
             key.append('-').append(run.getNumber());
         }
         key.append('-').append(getRootUrl());
@@ -1079,7 +1100,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
         StringBuilder key = new StringBuilder();
 
-        if (prependParentProjectKey || getDescriptor().isPrependParentProjectKey()) {
+        if (prependParentProjectKey || getGlobalDescriptor().isPrependParentProjectKey()) {
             if (null != run.getParent().getParent()) {
                 key.append(run.getParent().getParent().getFullName()).append('-');
             }

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifier/config.jelly
@@ -1,0 +1,47 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
+  <f:entry title="Bitbucket project key" field="bitbucketProjectKey">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="Bitbucket repository slug" field="repositorySlug">
+    <f:textbox />
+  </f:entry>
+  <f:advanced>
+    <f:entry title="Server base URL" field="stashServerBaseUrl">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="${%Credentials}" field="credentialsId">
+      <c:select/>
+    </f:entry>
+    <f:entry title="Commit SHA-1" field="commitSha1">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="Build Key" field="buildKey">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="Build Name" field="buildName">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="Build URL" field="buildUrl">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="Build Status" field="buildStatus">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="Ignore unverified SSL certificates" field="ignoreUnverifiedSSLPeer">
+      <f:checkbox />
+    </f:entry>
+    <f:entry title="Keep repeated builds in Bitbucket" field="includeBuildNumberInKey">
+      <f:checkbox />
+    </f:entry>
+    <f:entry title="Prepend parent project name to key" field="prependParentProjectKey">
+      <f:checkbox />
+    </f:entry>
+    <f:entry title="Disable INPROGRESS notification" field="disableInprogressNotification">
+      <f:checkbox />
+    </f:entry>
+    <f:entry title="Consider UNSTABLE builds as SUCCESS notification" field="considerUnstableAsSuccess">
+      <f:checkbox />
+    </f:entry>
+  </f:advanced>
+</j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifier/help-bitbucketProjectKey.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifier/help-bitbucketProjectKey.html
@@ -1,0 +1,3 @@
+<div>
+  The key of the Bitbucket project containing the repository. Token macros are supported.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifier/help-buildKey.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifier/help-buildKey.html
@@ -1,0 +1,3 @@
+<div>
+  Overrides the key of this build status. This is the equivalent of the projectKey option on notifyBitbucket.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifier/help-repositorySlug.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifier/help-repositorySlug.html
@@ -1,0 +1,3 @@
+<div>
+  The slug of the Bitbucket repository receiving the build status. Token macros are supported.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactoryTest.java
@@ -40,4 +40,26 @@ class BuildStatusUriFactoryTest {
         URI actual = BuildStatusUriFactory.create(baseUri, "25a4b3c9b494fc7ac65b80e3b0ecce63f235f20d");
         assertThat(actual, equalTo(expected));
     }
+
+    @Test
+    void shouldCreateRequiredBuildUri() {
+        URI expected = URI.create("http://localhost:12345/bitbucket/rest/api/latest/projects/PROJ/repos/my-repo/commits/25a4b3c9/builds");
+        URI actual = BuildStatusUriFactory.createRequiredBuild(
+                "http://localhost:12345/bitbucket/",
+                "PROJ",
+                "my-repo",
+                "25a4b3c9");
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    void shouldEncodeRequiredBuildUriSegments() {
+        URI expected = URI.create("http://localhost:12345/rest/api/latest/projects/my%20project/repos/my%20repo/commits/a%2Fb/builds");
+        URI actual = BuildStatusUriFactory.createRequiredBuild(
+                "http://localhost:12345",
+                "my project",
+                "my repo",
+                "a/b");
+        assertThat(actual, equalTo(expected));
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifierTest.java
@@ -1,0 +1,172 @@
+package org.jenkinsci.plugins.stashNotifier;
+
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.model.Run;
+import jenkins.branch.MultiBranchProject;
+import jenkins.model.JenkinsLocationConfiguration;
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RequiredBuildNotifierTest {
+
+    @Test
+    void shouldExposeRequiredAndInheritedConfiguration() {
+        try (MockedStatic<JenkinsLocationConfiguration> configuration = mockStatic(JenkinsLocationConfiguration.class)) {
+            RequiredBuildNotifier notifier = new RequiredBuildNotifier("PROJ", "my-repo");
+            notifier.setBuildKey("build-key");
+            notifier.setBuildName("build-name");
+            notifier.setBuildUrl("https://jenkins.example/job/1");
+
+            assertThat(notifier.getBitbucketProjectKey(), is("PROJ"));
+            assertThat(notifier.getRepositorySlug(), is("my-repo"));
+            assertThat(notifier.getBuildKey(), is("build-key"));
+            assertThat(notifier.getBuildName(), is("build-name"));
+            assertThat(notifier.getBuildUrl(), is("https://jenkins.example/job/1"));
+        }
+    }
+
+    @Test
+    void shouldCreateRequiredBuildUriFromExpandedCoordinates() throws Exception {
+        RequiredBuildNotifier notifier = newNotifier("$PROJECT", "$REPOSITORY");
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        BuildListener listener = mock(BuildListener.class);
+        doReturn("PROJ").when(notifier).expandValue(build, listener, "$PROJECT");
+        doReturn("my-repo").when(notifier).expandValue(build, listener, "$REPOSITORY");
+
+        URI actual = notifier.createBuildStatusUri(
+                "https://bitbucket.example/bitbucket",
+                "25a4b3c9",
+                build,
+                listener);
+
+        assertThat(actual, equalTo(URI.create(
+                "https://bitbucket.example/bitbucket/rest/api/latest/projects/PROJ/repos/my-repo/commits/25a4b3c9/builds")));
+    }
+
+    @Test
+    void shouldRejectEmptyExpandedCoordinates() throws Exception {
+        RequiredBuildNotifier notifier = newNotifier("$PROJECT", "repo");
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        BuildListener listener = mock(BuildListener.class);
+        doReturn(" ").when(notifier).expandValue(build, listener, "$PROJECT");
+        doReturn("repo").when(notifier).expandValue(build, listener, "repo");
+
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> notifier.createBuildStatusUri("https://bitbucket.example", "abc", build, listener));
+
+        assertThat(error.getMessage(), is("Bitbucket project key must not be empty"));
+    }
+
+    @Test
+    void shouldUseJobFullNameAsParentForRegularJob() {
+        RequiredBuildNotifier notifier = newNotifier("PROJ", "repo");
+        Run<?, ?> run = mock(Run.class);
+        Job<?, ?> job = mock(Job.class);
+        doReturn(job).when(run).getParent();
+        when(job.getFullName()).thenReturn("folder/job");
+
+        assertThat(notifier.getBuildParent(run), is("folder/job"));
+    }
+
+    @Test
+    void shouldUseMultibranchProjectFullNameAsParent() {
+        RequiredBuildNotifier notifier = newNotifier("PROJ", "repo");
+        Run<?, ?> run = mock(Run.class);
+        Job<?, ?> branchJob = mock(Job.class);
+        MultiBranchProject<?, ?> multibranchProject = mock(MultiBranchProject.class);
+        doReturn(branchJob).when(run).getParent();
+        doReturn(multibranchProject).when(branchJob).getParent();
+        when(multibranchProject.getFullName()).thenReturn("folder/application");
+
+        assertThat(notifier.getBuildParent(run), is("folder/application"));
+    }
+
+    @Test
+    void shouldAddParentToPayload() {
+        RequiredBuildNotifier notifier = newNotifier("PROJ", "repo");
+        Run<?, ?> run = mock(Run.class);
+        BuildListener listener = mock(BuildListener.class);
+        doReturn("branch-key").when(notifier).getBuildKey(run, listener);
+        doReturn("application").when(notifier).getBuildParent(run);
+        notifier.setBuildName("build-name");
+        notifier.setBuildUrl("https://jenkins.example/job/1");
+        when(run.getDescription()).thenReturn("description");
+
+        JSONObject payload = notifier.createNotificationPayload(run, StashBuildState.SUCCESSFUL, listener);
+
+        assertThat(payload.getString("state"), is("SUCCESSFUL"));
+        assertThat(payload.getString("key"), is("branch-key"));
+        assertThat(payload.getString("parent"), is("application"));
+    }
+
+    @Test
+    void shouldSendRequiredBuildNotification() throws Exception {
+        RequiredBuildNotifier notifier = newNotifier("PROJ", "repo");
+        Run<?, ?> run = mock(Run.class);
+        Job<?, ?> job = mock(Job.class);
+        BuildListener listener = mock(BuildListener.class);
+        HttpNotifier httpNotifier = mock(HttpNotifier.class);
+        HttpNotifierSelector selector = mock(HttpNotifierSelector.class);
+        StashNotifier.DescriptorImpl globalDescriptor = mock(StashNotifier.DescriptorImpl.class);
+        NotificationResult expectedResult = NotificationResult.newSuccess();
+
+        doReturn(job).when(run).getParent();
+        when(job.getFullName()).thenReturn("folder/application/branch");
+        when(run.getExternalizableId()).thenReturn("folder/application/branch#1");
+        when(listener.getLogger()).thenReturn(System.out);
+        when(httpNotifier.send(any(), any(), any(), any())).thenReturn(expectedResult);
+        when(selector.select(any())).thenReturn(httpNotifier);
+        doReturn(globalDescriptor).when(notifier).getGlobalDescriptor();
+        doReturn("build-key").when(notifier).getBuildKey(run, listener);
+        doReturn("folder/application").when(notifier).getBuildParent(run);
+        doReturn("PROJ").when(notifier).expandValue(run, listener, "PROJ");
+        doReturn("repo").when(notifier).expandValue(run, listener, "repo");
+        notifier.setHttpNotifierSelector(selector);
+        notifier.setStashServerBaseUrl("https://bitbucket.example");
+        notifier.setBuildName("build-name");
+        notifier.setBuildUrl("https://jenkins.example/job/1");
+        when(run.getDescription()).thenReturn("description");
+
+        NotificationResult actualResult = notifier.notifyStash(
+                System.out,
+                run,
+                "25a4b3c9",
+                listener,
+                StashBuildState.SUCCESSFUL);
+
+        ArgumentCaptor<URI> uri = ArgumentCaptor.forClass(URI.class);
+        ArgumentCaptor<JSONObject> payload = ArgumentCaptor.forClass(JSONObject.class);
+        verify(httpNotifier).send(uri.capture(), payload.capture(), any(), any());
+        assertThat(actualResult, is(expectedResult));
+        assertThat(uri.getValue(), equalTo(URI.create(
+                "https://bitbucket.example/rest/api/latest/projects/PROJ/repos/repo/commits/25a4b3c9/builds")));
+        assertThat(payload.getValue().getString("parent"), is("folder/application"));
+    }
+
+    private RequiredBuildNotifier newNotifier(String projectKey, String repositorySlug) {
+        try (MockedStatic<JenkinsLocationConfiguration> configuration = mockStatic(JenkinsLocationConfiguration.class)) {
+            return spy(new RequiredBuildNotifier(projectKey, repositorySlug));
+        }
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/RequiredBuildNotifierTest.java
@@ -1,8 +1,10 @@
 package org.jenkinsci.plugins.stashNotifier;
 
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
-import hudson.model.ItemGroup;
+import hudson.model.FreeStyleProject;
 import hudson.model.Job;
 import hudson.model.Run;
 import jenkins.branch.MultiBranchProject;
@@ -19,7 +21,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -93,10 +94,9 @@ class RequiredBuildNotifierTest {
     void shouldUseMultibranchProjectFullNameAsParent() {
         RequiredBuildNotifier notifier = newNotifier("PROJ", "repo");
         Run<?, ?> run = mock(Run.class);
-        Job<?, ?> branchJob = mock(Job.class);
         MultiBranchProject<?, ?> multibranchProject = mock(MultiBranchProject.class);
+        FreeStyleProject branchJob = new FreeStyleProject(multibranchProject, "branch");
         doReturn(branchJob).when(run).getParent();
-        doReturn(multibranchProject).when(branchJob).getParent();
         when(multibranchProject.getFullName()).thenReturn("folder/application");
 
         assertThat(notifier.getBuildParent(run), is("folder/application"));
@@ -123,8 +123,8 @@ class RequiredBuildNotifierTest {
     @Test
     void shouldSendRequiredBuildNotification() throws Exception {
         RequiredBuildNotifier notifier = newNotifier("PROJ", "repo");
-        Run<?, ?> run = mock(Run.class);
-        Job<?, ?> job = mock(Job.class);
+        AbstractBuild<?, ?> run = mock(AbstractBuild.class);
+        AbstractProject<?, ?> job = mock(AbstractProject.class);
         BuildListener listener = mock(BuildListener.class);
         HttpNotifier httpNotifier = mock(HttpNotifier.class);
         HttpNotifierSelector selector = mock(HttpNotifierSelector.class);
@@ -134,6 +134,7 @@ class RequiredBuildNotifierTest {
         doReturn(job).when(run).getParent();
         when(job.getFullName()).thenReturn("folder/application/branch");
         when(run.getExternalizableId()).thenReturn("folder/application/branch#1");
+        when(run.getWorkspace()).thenReturn(mock(FilePath.class));
         when(listener.getLogger()).thenReturn(System.out);
         when(httpNotifier.send(any(), any(), any(), any())).thenReturn(expectedResult);
         when(selector.select(any())).thenReturn(httpNotifier);


### PR DESCRIPTION
Adds a dedicated `notifyBitbucketRequiredBuild` Pipeline step for Bitbucket Required Builds merge check.

The new step:

- sends build statuses to the repository-scoped build status endpoint
- accepts the required `bitbucketProjectKey` and `repositorySlug` arguments
- supports the existing `notifyBitbucket` configuration options
- exposes the existing build key override as `buildKey` insted of the ambiguous `projectKey`
- includes the build `parent` expected by Required Builds, using the multibranch project path for multibranch jobs and the job path for regular jobs
- keeps the existing `notifyBitbucket` step and existing bitbucket endpoint unchanged

Fixes #429 #290

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
