### PR TITLE
feat: Add configurable bitbucket builds api

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,3 +17,27 @@ jobs:
     secrets:
       MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
       MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+
+  integration-tests:
+    needs: maven-cd
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      checks: read
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'check_run' && github.event.check_run.head_sha || github.sha }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Run Jenkins Pipeline integration tests
+        run: mvn --batch-mode --no-transfer-progress -Dtest=BitbucketNotifierPipelineIT test

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
         <hpi.compatibleSinceVersion>1.9</hpi.compatibleSinceVersion>
+        <wiremock.version>3.13.2</wiremock.version>
     </properties>
     <artifactId>stashNotifier</artifactId>
     <version>${revision}.${changelist}</version>
@@ -106,6 +107,10 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>branch-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
             <type>jar</type>
         </dependency>
@@ -137,6 +142,32 @@
         <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,6 @@ node {
 
     try {
         // Do stuff
-
         currentBuild.result = 'SUCCESS'     // Set result of currentBuild !Important!
     } catch(err) {
         currentBuild.result = 'FAILURE'     // Set result of currentBuild !Important!
@@ -153,6 +152,28 @@ pipeline {
     }
 }
 ```
+
+### Builds API and Required Builds
+
+Bitbucket Data Center 7.4 and newer provides the Builds API used by the
+Required Builds merge check. Select **Builds API** as the global default,
+or override the API for an individual notification:
+
+```groovy
+notifyBitbucket(
+        useBuildsApi: true,
+        bitbucketProjectKey: 'PROJ',
+        repositorySlug: 'my-repository',
+        credentialsId: '00000000-1111-2222-3333-123456789abc',
+        stashServerBaseUrl: 'https://my.company.intranet/bitbucket')
+```
+
+`bitbucketProjectKey` and `repositorySlug` identify the repository in Bitbucket
+and are required whenever the Builds API is selected. Both support token macros.
+When `useBuildsApi` is omitted, `notifyBitbucket` uses the global default. Use
+`useBuildsApi: false` to override a Builds API global default for
+an individual notification. For a multibranch Pipeline, the build parent is the
+full Jenkins path of the multibranch project without the branch name.
 
 ### Note on credentials
 

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactory.java
@@ -1,8 +1,12 @@
 package org.jenkinsci.plugins.stashNotifier;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
 
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class BuildStatusUriFactory {
     private BuildStatusUriFactory() {
@@ -12,5 +16,25 @@ public class BuildStatusUriFactory {
         String tidyBase = StringUtils.removeEnd(baseUri, "/");
         String uri = String.join("/", tidyBase, "rest/build-status/1.0/commits", commit);
         return URI.create(uri);
+    }
+
+    public static URI createBuildsApi(String baseUri, String projectKey, String repositorySlug, String commit) {
+        try {
+            URIBuilder builder = new URIBuilder(StringUtils.removeEnd(baseUri, "/"));
+            List<String> pathSegments = new ArrayList<>(builder.getPathSegments());
+            pathSegments.add("rest");
+            pathSegments.add("api");
+            pathSegments.add("latest");
+            pathSegments.add("projects");
+            pathSegments.add(projectKey);
+            pathSegments.add("repos");
+            pathSegments.add(repositorySlug);
+            pathSegments.add("commits");
+            pathSegments.add(commit);
+            pathSegments.add("builds");
+            return builder.setPathSegments(pathSegments).build();
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Unable to create Builds API URI", e);
+        }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/stashNotifier/StashNotifier.java
@@ -40,6 +40,7 @@ import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import jenkins.branch.MultiBranchProject;
 import jenkins.model.Jenkins;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.tasks.SimpleBuildStep;
@@ -172,6 +173,22 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
      * whether to consider UNSTABLE builds as failures or success
      */
     private boolean considerUnstableAsSuccess;
+
+    /**
+     * Overrides the globally configured build status API.
+     * If null, the global default is used.
+     */
+    private Boolean useBuildsApi;
+
+    /**
+     * Bitbucket project containing the repository. Required by the Builds API.
+     */
+    private String bitbucketProjectKey;
+
+    /**
+     * Bitbucket repository receiving the build status. Required by the Builds API.
+     */
+    private String repositorySlug;
 
     private JenkinsLocationConfiguration globalConfig;
 
@@ -341,6 +358,33 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         this.considerUnstableAsSuccess = considerUnstableAsSuccess;
     }
 
+    public Boolean getUseBuildsApi() {
+        return useBuildsApi;
+    }
+
+    @DataBoundSetter
+    public void setUseBuildsApi(Boolean useBuildsApi) {
+        this.useBuildsApi = useBuildsApi;
+    }
+
+    public String getBitbucketProjectKey() {
+        return bitbucketProjectKey;
+    }
+
+    @DataBoundSetter
+    public void setBitbucketProjectKey(String bitbucketProjectKey) {
+        this.bitbucketProjectKey = bitbucketProjectKey;
+    }
+
+    public String getRepositorySlug() {
+        return repositorySlug;
+    }
+
+    @DataBoundSetter
+    public void setRepositorySlug(String repositorySlug) {
+        this.repositorySlug = repositorySlug;
+    }
+
     @Inject
     void setHttpNotifierSelector(HttpNotifierSelector httpNotifierSelector) {
         this.httpNotifierSelector = httpNotifierSelector;
@@ -433,8 +477,8 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
      * @param workspace the workspace of a non-AbstractBuild build
      * @param listener  the Jenkins build listener
      * @param state     the state of the build (in progress, success, failed)
-     * @return always true in order not to abort the Job in case of
-     * notification failures
+     * @return false for an invalid notifier configuration; true otherwise, so
+     * notification delivery failures do not abort the job
      */
     private boolean processJenkinsEvent(
             final Run<?, ?> run,
@@ -443,6 +487,13 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             final StashBuildState state) {
 
         PrintStream logger = listener.getLogger();
+
+        try {
+            validateBuildsApiConfiguration();
+        } catch (IllegalArgumentException e) {
+            logger.println("Cannot notify Bitbucket! (" + e.getMessage() + ")");
+            return false;
+        }
 
         // Exit if Jenkins root URL is not configured. Bitbucket run API
         // requires valid link to run in CI system.
@@ -532,7 +583,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
      */
     @Deprecated
     protected CloseableHttpClient getHttpClient(PrintStream logger, Run<?, ?> run, String stashServer) throws Exception {
-        DescriptorImpl globalSettings = getDescriptor();
+        DescriptorImpl globalSettings = getGlobalDescriptor();
 
         final int timeoutInMilliseconds = 60_000;
 
@@ -638,10 +689,8 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         }
     }
 
-    @Override
-    public DescriptorImpl getDescriptor() {
-        // see Descriptor javadoc for more about what a descriptor is.
-        return (DescriptorImpl) super.getDescriptor();
+    protected DescriptorImpl getGlobalDescriptor() {
+        return Jenkins.get().getDescriptorByType(DescriptorImpl.class);
     }
 
     @Symbol({"notifyBitbucket", "notifyStash"})
@@ -664,6 +713,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         private boolean includeBuildNumberInKey;
         private boolean prependParentProjectKey;
         private String stashRootUrl;
+        private boolean defaultUseBuildsApi;
 
         public DescriptorImpl() {
             this(true);
@@ -765,6 +815,33 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             this.stashRootUrl = StringUtils.trimToNull(stashRootUrl);
         }
 
+        public boolean isDefaultUseBuildsApi() {
+            return defaultUseBuildsApi;
+        }
+
+        @DataBoundSetter
+        public void setDefaultUseBuildsApi(boolean defaultUseBuildsApi) {
+            this.defaultUseBuildsApi = defaultUseBuildsApi;
+        }
+
+        public ListBoxModel doFillDefaultUseBuildsApiItems() {
+            return bitbucketBuildStatusApiItems(false);
+        }
+
+        public ListBoxModel doFillUseBuildsApiItems() {
+            return bitbucketBuildStatusApiItems(true);
+        }
+
+        private ListBoxModel bitbucketBuildStatusApiItems(boolean includeGlobalDefault) {
+            ListBoxModel items = new ListBoxModel();
+            if (includeGlobalDefault) {
+                items.add("Use global default", "");
+            }
+            items.add("Legacy", "false");
+            items.add("Builds API (Bitbucket 7.4 or newer)", "true");
+            return items;
+        }
+
         public FormValidation doCheckCredentialsId(@QueryParameter String value, @AncestorInPath Item project) {
             if (project != null && StringUtils.isBlank(value) && StringUtils.isBlank(credentialsId)) {
                 return FormValidation.error("Please specify the credentials to use");
@@ -823,6 +900,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             this.includeBuildNumberInKey = false;
             this.prependParentProjectKey = false;
             this.stashRootUrl = null;
+            this.defaultUseBuildsApi = false;
 
             req.bindJSON(this, formData);
 
@@ -862,9 +940,16 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         Credentials stringCredentials
                 = getCredentials(StringCredentials.class, run.getParent());
 
-        URI uri = BuildStatusUriFactory.create(stashURL, commitSha1);
+        URI uri;
+        try {
+            uri = createBuildStatusUri(stashURL, commitSha1, run, listener);
+        } catch (RuntimeException e) {
+            logger.println("Unable to create Bitbucket build status URL: " + e.getMessage());
+            LOGGER.error("{} unable to create Bitbucket build status URL", idOf(run), e);
+            return NotificationResult.newFailure(e.getMessage());
+        }
         NotificationSettings settings = new NotificationSettings(
-                ignoreUnverifiedSSLPeer || getDescriptor().isIgnoreUnverifiedSsl(),
+                ignoreUnverifiedSSLPeer || getGlobalDescriptor().isIgnoreUnverifiedSsl(),
                 stringCredentials != null ? stringCredentials : usernamePasswordCredentials
         );
         NotificationContext context = new NotificationContext(
@@ -873,6 +958,58 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         );
         HttpNotifier notifier = getHttpNotifierSelector().select(new SelectionContext(run.getParent().getFullName()));
         return notifier.send(uri, payload, settings, context);
+    }
+
+    protected URI createBuildStatusUri(
+            String stashURL,
+            String commitSha1,
+            Run<?, ?> run,
+            TaskListener listener) {
+        if (isBuildsApiEnabled()) {
+            try {
+                String expandedProjectKey = expandValue(run, listener, bitbucketProjectKey);
+                String expandedRepositorySlug = expandValue(run, listener, repositorySlug);
+                if (StringUtils.isBlank(expandedProjectKey)) {
+                    throw new IllegalArgumentException("bitbucketProjectKey must not be empty");
+                }
+                if (StringUtils.isBlank(expandedRepositorySlug)) {
+                    throw new IllegalArgumentException("repositorySlug must not be empty");
+                }
+                return BuildStatusUriFactory.createBuildsApi(
+                        stashURL,
+                        expandedProjectKey,
+                        expandedRepositorySlug,
+                        commitSha1);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalArgumentException("Unable to expand Bitbucket repository coordinates", e);
+            } catch (IOException | MacroEvaluationException e) {
+                throw new IllegalArgumentException("Unable to expand Bitbucket repository coordinates", e);
+            }
+        }
+        return BuildStatusUriFactory.create(stashURL, commitSha1);
+    }
+
+    boolean isBuildsApiEnabled() {
+        if (useBuildsApi != null) {
+            return useBuildsApi;
+        }
+        DescriptorImpl descriptor = getGlobalDescriptor();
+        return descriptor != null && descriptor.isDefaultUseBuildsApi();
+    }
+
+    void validateBuildsApiConfiguration() {
+        if (!isBuildsApiEnabled()) {
+            return;
+        }
+        if (StringUtils.isBlank(bitbucketProjectKey)) {
+            throw new IllegalArgumentException(
+                    "bitbucketProjectKey is required when useBuildsApi is true");
+        }
+        if (StringUtils.isBlank(repositorySlug)) {
+            throw new IllegalArgumentException(
+                    "repositorySlug is required when useBuildsApi is true");
+        }
     }
 
     /**
@@ -898,7 +1035,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         }
 
         if (credentials == null) {
-            DescriptorImpl descriptor = getDescriptor();
+            DescriptorImpl descriptor = getGlobalDescriptor();
             if (StringUtils.isBlank(credentialsId) && descriptor != null) {
                 credentialsId = descriptor.getCredentialsId();
             }
@@ -971,7 +1108,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
     private String expandStashURL(Run<?, ?> run, final TaskListener listener) {
         String url = stashServerBaseUrl;
-        DescriptorImpl descriptor = getDescriptor();
+        DescriptorImpl descriptor = getGlobalDescriptor();
         if (url == null || url.isEmpty()) {
             url = descriptor.getStashRootUrl();
         }
@@ -989,6 +1126,14 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
             LOGGER.error("{} unable to expand Bitbucket server URL", idOf(run), ex);
         }
         return url;
+    }
+
+    protected String expandValue(Run<?, ?> run, TaskListener listener, String value)
+            throws IOException, InterruptedException, MacroEvaluationException {
+        if (run instanceof AbstractBuild<?, ?>) {
+            return TokenMacro.expandAll((AbstractBuild<?, ?>) run, listener, value);
+        }
+        return TokenMacro.expandAll(run, new FilePath(run.getRootDir()), listener, value);
     }
 
     /**
@@ -1017,7 +1162,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
      * @param run the run to notify Bitbucket of
      * @return JSON body for POST to Bitbucket build API
      */
-    private JSONObject createNotificationPayload(
+    protected JSONObject createNotificationPayload(
             final Run<?, ?> run,
             final StashBuildState state,
             TaskListener listener) {
@@ -1028,10 +1173,21 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
         json.put("name", abbreviate(getBuildName(run), MAX_FIELD_LENGTH));
         json.put("description", abbreviate(getBuildDescription(run, state), MAX_FIELD_LENGTH));
         json.put("url", abbreviate(getBuildUrl(run), MAX_URL_FIELD_LENGTH));
+        if (isBuildsApiEnabled()) {
+            json.put("parent", abbreviate(getBuildParent(run), MAX_FIELD_LENGTH));
+        }
         return json;
     }
 
-    private static String abbreviate(String text, int maxWidth) {
+    String getBuildParent(Run<?, ?> run) {
+        ItemGroup<?> parent = run.getParent().getParent();
+        if (parent instanceof MultiBranchProject<?, ?>) {
+            return parent.getFullName();
+        }
+        return run.getParent().getFullName();
+    }
+
+    protected static String abbreviate(String text, int maxWidth) {
         if (text == null) {
             return null;
         }
@@ -1055,7 +1211,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
         key.append(run.getParent().getName());
         if (includeBuildNumberInKey
-                || getDescriptor().isIncludeBuildNumberInKey()) {
+                || getGlobalDescriptor().isIncludeBuildNumberInKey()) {
             key.append('-').append(run.getNumber());
         }
         key.append('-').append(getRootUrl());
@@ -1079,7 +1235,7 @@ public class StashNotifier extends Notifier implements SimpleBuildStep {
 
         StringBuilder key = new StringBuilder();
 
-        if (prependParentProjectKey || getDescriptor().isPrependParentProjectKey()) {
+        if (prependParentProjectKey || getGlobalDescriptor().isPrependParentProjectKey()) {
             if (null != run.getParent().getParent()) {
                 key.append(run.getParent().getParent().getFullName()).append('-');
             }

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/config.jelly
@@ -1,6 +1,15 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:advanced>
+    <f:entry title="Bitbucket build status API" field="useBuildsApi">
+      <f:select />
+    </f:entry>
+    <f:entry title="Bitbucket project key" field="bitbucketProjectKey">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="Bitbucket repository slug" field="repositorySlug">
+      <f:textbox />
+    </f:entry>
     <f:entry title="Server base URL" field="stashServerBaseUrl">
       <f:textbox />
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/global.jelly
@@ -6,6 +6,10 @@
              help="${rootURL}/plugin/stashNotifier/help-globalConfig-stashRootUrl.html">
       <f:textbox />
     </f:entry>
+    <f:entry title="Bitbucket build status API"
+             field="defaultUseBuildsApi">
+      <f:select />
+    </f:entry>
     <f:entry title="${%Credentials}" field="credentialsId">
       <c:select/>
     </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-bitbucketProjectKey.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-bitbucketProjectKey.html
@@ -1,0 +1,4 @@
+<div>
+  The key of the Bitbucket project containing the repository. Required by the Builds API.
+  Token macros are supported.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-defaultUseBuildsApi.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-defaultUseBuildsApi.html
@@ -1,0 +1,31 @@
+<div>
+  <p>
+    Defines the API used by <code>notifyBitbucket</code> when
+    <code>useBuildsApi</code> is not specified.
+  </p>
+  <p>
+    <strong>Legacy</strong> uses the commit-scoped build status endpoint:
+    <code>/rest/build-status/1.0/commits/{commitId}</code>.
+  </p>
+  <p>
+    <strong>Builds API</strong> is available in Bitbucket Server and Data Center 7.4 or newer and uses
+    the repository-scoped builds endpoint:
+    <code>/rest/api/latest/projects/{projectKey}/repos/{repositorySlug}/commits/{commitId}/builds</code>.
+  </p>
+  <p>
+    The Builds API requires <code>bitbucketProjectKey</code> and <code>repositorySlug</code>.
+    It supports additional build information and compatibility with the Required Builds merge check.
+  </p>
+  <p>
+    A Pipeline can override this default by setting <code>useBuildsApi: true</code> or
+    <code>useBuildsApi: false</code>.
+  </p>
+  <p>
+    See the
+    <a href="https://developer.atlassian.com/server/bitbucket/how-tos/updating-build-status-for-commits/"
+       target="_blank" rel="noopener noreferrer">Bitbucket Builds API documentation</a>
+    and the
+    <a href="https://developer.atlassian.com/server/bitbucket/reference/api-changelog/#new-rich-build-status"
+       target="_blank" rel="noopener noreferrer">Bitbucket API changelog</a>.
+  </p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-repositorySlug.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-repositorySlug.html
@@ -1,0 +1,4 @@
+<div>
+  The slug of the Bitbucket repository receiving the build status. Required by the Builds API.
+  Token macros are supported.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-useBuildsApi.html
+++ b/src/main/resources/org/jenkinsci/plugins/stashNotifier/StashNotifier/help-useBuildsApi.html
@@ -1,0 +1,4 @@
+<div>
+  Overrides the globally configured Bitbucket build status API. Select <strong>Builds API</strong>
+  to use the repository-scoped endpoint available in Bitbucket 7.4 or newer.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/BitbucketNotifierPipelineIT.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/BitbucketNotifierPipelineIT.java
@@ -1,0 +1,155 @@
+package org.jenkinsci.plugins.stashNotifier;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import hudson.model.Result;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlSelect;
+import org.htmlunit.html.HtmlTextInput;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.noContent;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+
+@WithJenkins
+@WireMockTest
+class BitbucketNotifierPipelineIT {
+
+    @Test
+    void notifyBitbucketUsesLegacyApiFromGlobalConfiguration(
+            JenkinsRule jenkins, WireMockRuntimeInfo bitbucketServer) throws Exception {
+        WireMock bitbucket = prepareBitbucket(bitbucketServer);
+        saveGlobalConfiguration(
+                jenkins,
+                bitbucketServer.getHttpBaseUrl() + "/configured",
+                false);
+
+        runPipeline(jenkins, "notify-bitbucket", """
+                notifyBitbucket(commitSha1: '2222222222222222')
+                """);
+
+        verifySinglePost(bitbucket, "/configured/rest/build-status/1.0/commits/2222222222222222");
+    }
+
+    @Test
+    void notifyBitbucketUsesBuildsApiFromGlobalConfiguration(
+            JenkinsRule jenkins, WireMockRuntimeInfo bitbucketServer) throws Exception {
+        WireMock bitbucket = prepareBitbucket(bitbucketServer);
+        saveGlobalConfiguration(
+                jenkins,
+                bitbucketServer.getHttpBaseUrl() + "/configured",
+                true);
+
+        runPipeline(jenkins, "notify-bitbucket-builds-api", """
+                notifyBitbucket(
+                    bitbucketProjectKey: 'PROJECT',
+                    repositorySlug: 'repository',
+                    commitSha1: '1111111111111111')
+                """);
+
+        verifySinglePost(
+                bitbucket,
+                "/configured/rest/api/latest/projects/PROJECT/repos/repository/commits/1111111111111111/builds");
+    }
+
+    @Test
+    void notifyBitbucketCanOverrideGlobalApiSelection(
+            JenkinsRule jenkins, WireMockRuntimeInfo bitbucketServer) throws Exception {
+        WireMock bitbucket = prepareBitbucket(bitbucketServer);
+        saveGlobalConfiguration(
+                jenkins,
+                bitbucketServer.getHttpBaseUrl() + "/configured",
+                true);
+
+        runPipeline(jenkins, "notify-bitbucket-api-override", """
+                notifyBitbucket(
+                    useBuildsApi: false,
+                    commitSha1: '3333333333333333')
+                """);
+
+        verifySinglePost(bitbucket, "/configured/rest/build-status/1.0/commits/3333333333333333");
+    }
+
+    @Test
+    void notifyBitbucketCanEnableBuildsApiLocally(
+            JenkinsRule jenkins, WireMockRuntimeInfo bitbucketServer) throws Exception {
+        WireMock bitbucket = prepareBitbucket(bitbucketServer);
+        saveGlobalConfiguration(
+                jenkins,
+                bitbucketServer.getHttpBaseUrl() + "/configured",
+                false);
+
+        runPipeline(jenkins, "notify-bitbucket-builds-api-override", """
+                notifyBitbucket(
+                    useBuildsApi: true,
+                    bitbucketProjectKey: 'PROJECT',
+                    repositorySlug: 'repository',
+                    commitSha1: '5555555555555555')
+                """);
+
+        verifySinglePost(
+                bitbucket,
+                "/configured/rest/api/latest/projects/PROJECT/repos/repository/commits/5555555555555555/builds");
+    }
+
+    @Test
+    void buildsApiRequiresRepositoryCoordinates(
+            JenkinsRule jenkins, WireMockRuntimeInfo bitbucketServer) throws Exception {
+        WireMock bitbucket = prepareBitbucket(bitbucketServer);
+        saveGlobalConfiguration(
+                jenkins,
+                bitbucketServer.getHttpBaseUrl() + "/configured",
+                true);
+
+        WorkflowRun build = schedulePipeline(jenkins, "notify-bitbucket-missing-coordinates", """
+                notifyBitbucket(commitSha1: '4444444444444444')
+                """);
+
+        jenkins.assertBuildStatus(Result.FAILURE, build);
+        bitbucket.verifyThat(0, postRequestedFor(anyUrl()));
+    }
+
+    private static WireMock prepareBitbucket(WireMockRuntimeInfo bitbucketServer) {
+        WireMock bitbucket = bitbucketServer.getWireMock();
+        bitbucket.register(post(anyUrl()).willReturn(noContent()));
+        return bitbucket;
+    }
+
+    private static void saveGlobalConfiguration(
+            JenkinsRule jenkins,
+            String bitbucketUrl,
+            boolean defaultUseBuildsApi) throws Exception {
+        HtmlPage page = jenkins.createWebClient().goTo("configure");
+        HtmlForm form = page.getFormByName("config");
+        HtmlTextInput serverUrl = form.getInputByName("_.stashRootUrl");
+        serverUrl.setValue(bitbucketUrl);
+        HtmlSelect api = form.getSelectByName("_.defaultUseBuildsApi");
+        api.setSelectedAttribute(Boolean.toString(defaultUseBuildsApi), true);
+        jenkins.submit(form);
+    }
+
+    private static void runPipeline(JenkinsRule jenkins, String name, String step) throws Exception {
+        jenkins.assertBuildStatusSuccess(schedulePipeline(jenkins, name, step));
+    }
+
+    private static WorkflowRun schedulePipeline(JenkinsRule jenkins, String name, String step) throws Exception {
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class, name);
+        job.setDefinition(new CpsFlowDefinition("node {\n" + step + "\n}", true));
+        return job.scheduleBuild2(0).get();
+    }
+
+    private static void verifySinglePost(WireMock bitbucket, String path) {
+        bitbucket.verifyThat(1, postRequestedFor(urlEqualTo(path)));
+        bitbucket.verifyThat(1, postRequestedFor(anyUrl()));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/BuildStatusUriFactoryTest.java
@@ -40,4 +40,26 @@ class BuildStatusUriFactoryTest {
         URI actual = BuildStatusUriFactory.create(baseUri, "25a4b3c9b494fc7ac65b80e3b0ecce63f235f20d");
         assertThat(actual, equalTo(expected));
     }
+
+    @Test
+    void shouldCreateBuildsApiUri() {
+        URI expected = URI.create("http://localhost:12345/bitbucket/rest/api/latest/projects/PROJ/repos/my-repo/commits/25a4b3c9/builds");
+        URI actual = BuildStatusUriFactory.createBuildsApi(
+                "http://localhost:12345/bitbucket/",
+                "PROJ",
+                "my-repo",
+                "25a4b3c9");
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    void shouldEncodeBuildsApiUriSegments() {
+        URI expected = URI.create("http://localhost:12345/rest/api/latest/projects/my%20project/repos/my%20repo/commits/a%2Fb/builds");
+        URI actual = BuildStatusUriFactory.createBuildsApi(
+                "http://localhost:12345",
+                "my project",
+                "my repo",
+                "a/b");
+        assertThat(actual, equalTo(expected));
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/ConfigAsCodeTest.java
@@ -25,6 +25,7 @@ class ConfigAsCodeTest {
 
         assertThat(stashNotifierConfig.isConsiderUnstableAsSuccess(), equalTo(true));
         assertThat(stashNotifierConfig.getCredentialsId(), equalTo("bitbucket-credentials"));
+        assertThat(stashNotifierConfig.isDefaultUseBuildsApi(), equalTo(true));
         assertThat(stashNotifierConfig.isDisableInprogressNotification(), equalTo(true));
         assertThat(stashNotifierConfig.isIgnoreUnverifiedSsl(), equalTo(true));
         assertThat(stashNotifierConfig.isIncludeBuildNumberInKey(), equalTo(true));

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/DescriptorImplTest.java
@@ -60,6 +60,7 @@ class DescriptorImplTest {
         json = new JSONObject();
         json.put("considerUnstableAsSuccess", "true");
         json.put("credentialsId", "bitbucket-credentials");
+        json.put("defaultUseBuildsApi", "true");
         json.put("disableInprogressNotification", "true");
         json.put("ignoreUnverifiedSsl", "true");
         json.put("includeBuildNumberInKey", "true");
@@ -98,12 +99,20 @@ class DescriptorImplTest {
         //then
         assertThat(desc.isApplicable(AbstractProject.class), is(true));
         assertThat(desc.getCredentialsId(), is("bitbucket-credentials"));
+        assertThat(desc.isDefaultUseBuildsApi(), is(true));
         assertThat(desc.isDisableInprogressNotification(), is(true));
         assertThat(desc.getDisplayName(), is("Notify Bitbucket Instance"));
         assertThat(desc.isIncludeBuildNumberInKey(), is(true));
         assertThat(desc.isIgnoreUnverifiedSsl(), is(true));
         assertThat(desc.isPrependParentProjectKey(), is(true));
         assertThat(desc.getStashRootUrl(), is("https://my.company.intranet/bitbucket"));
+    }
+
+    @Test
+    void defaultsToLegacyBuildStatusApi() {
+        StashNotifier.DescriptorImpl descriptor = new StashNotifier.DescriptorImpl(false);
+
+        assertThat(descriptor.isDefaultUseBuildsApi(), is(false));
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierBuildsApiTest.java
+++ b/src/test/java/org/jenkinsci/plugins/stashNotifier/StashNotifierBuildsApiTest.java
@@ -1,0 +1,199 @@
+package org.jenkinsci.plugins.stashNotifier;
+
+import hudson.FilePath;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleProject;
+import hudson.model.Run;
+import jenkins.branch.MultiBranchProject;
+import jenkins.model.JenkinsLocationConfiguration;
+import net.sf.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StashNotifierBuildsApiTest {
+
+    @Test
+    void shouldUseGlobalApiByDefaultAndAllowLocalOverride() {
+        StashNotifier notifier = newNotifier();
+        StashNotifier.DescriptorImpl globalDescriptor = mock(StashNotifier.DescriptorImpl.class);
+        doReturn(globalDescriptor).when(notifier).getGlobalDescriptor();
+        when(globalDescriptor.isDefaultUseBuildsApi()).thenReturn(true);
+
+        assertThat(notifier.isBuildsApiEnabled(), is(true));
+
+        notifier.setUseBuildsApi(false);
+
+        assertThat(notifier.isBuildsApiEnabled(), is(false));
+    }
+
+    @Test
+    void shouldRequireRepositoryCoordinatesForBuildsApi() {
+        StashNotifier notifier = buildsApiNotifier(null, "repository");
+
+        IllegalArgumentException missingProject = assertThrows(
+                IllegalArgumentException.class,
+                notifier::validateBuildsApiConfiguration);
+        assertThat(
+                missingProject.getMessage(),
+                is("bitbucketProjectKey is required when useBuildsApi is true"));
+
+        notifier.setBitbucketProjectKey("PROJECT");
+        notifier.setRepositorySlug(" ");
+
+        IllegalArgumentException missingRepository = assertThrows(
+                IllegalArgumentException.class,
+                notifier::validateBuildsApiConfiguration);
+        assertThat(
+                missingRepository.getMessage(),
+                is("repositorySlug is required when useBuildsApi is true"));
+    }
+
+    @Test
+    void shouldCreateBuildsApiUriFromExpandedCoordinates() throws Exception {
+        StashNotifier notifier = buildsApiNotifier("$PROJECT", "$REPOSITORY");
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        BuildListener listener = mock(BuildListener.class);
+        doReturn("PROJECT").when(notifier).expandValue(build, listener, "$PROJECT");
+        doReturn("repository").when(notifier).expandValue(build, listener, "$REPOSITORY");
+
+        URI actual = notifier.createBuildStatusUri(
+                "https://bitbucket.example/bitbucket",
+                "25a4b3c9",
+                build,
+                listener);
+
+        assertThat(actual, equalTo(URI.create(
+                "https://bitbucket.example/bitbucket/rest/api/latest/projects/PROJECT/repos/repository/commits/25a4b3c9/builds")));
+    }
+
+    @Test
+    void shouldRejectEmptyExpandedRepositoryCoordinates() throws Exception {
+        StashNotifier notifier = buildsApiNotifier("$PROJECT", "repository");
+        AbstractBuild<?, ?> build = mock(AbstractBuild.class);
+        BuildListener listener = mock(BuildListener.class);
+        doReturn(" ").when(notifier).expandValue(build, listener, "$PROJECT");
+        doReturn("repository").when(notifier).expandValue(build, listener, "repository");
+
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> notifier.createBuildStatusUri("https://bitbucket.example", "abc", build, listener));
+
+        assertThat(error.getMessage(), is("bitbucketProjectKey must not be empty"));
+    }
+
+    @Test
+    void shouldUseMultibranchProjectAsBuildParent() {
+        StashNotifier notifier = buildsApiNotifier("PROJECT", "repository");
+        Run<?, ?> run = mock(Run.class);
+        MultiBranchProject<?, ?> multibranchProject = mock(MultiBranchProject.class);
+        FreeStyleProject branchJob = new FreeStyleProject(multibranchProject, "branch");
+        doReturn(branchJob).when(run).getParent();
+        when(multibranchProject.getFullName()).thenReturn("folder/application");
+
+        assertThat(notifier.getBuildParent(run), is("folder/application"));
+    }
+
+    @Test
+    void shouldAddParentOnlyToBuildsApiPayload() {
+        StashNotifier notifier = buildsApiNotifier("PROJECT", "repository");
+        Run<?, ?> run = mock(Run.class);
+        BuildListener listener = mock(BuildListener.class);
+        doReturn("branch-key").when(notifier).getBuildKey(run, listener);
+        doReturn("application").when(notifier).getBuildParent(run);
+        notifier.setBuildName("build-name");
+        notifier.setBuildUrl("https://jenkins.example/job/1");
+        when(run.getDescription()).thenReturn("description");
+
+        JSONObject buildsApiPayload = notifier.createNotificationPayload(run, StashBuildState.SUCCESSFUL, listener);
+        notifier.setUseBuildsApi(false);
+        JSONObject standardPayload = notifier.createNotificationPayload(run, StashBuildState.SUCCESSFUL, listener);
+
+        assertThat(buildsApiPayload.getString("parent"), is("application"));
+        assertThat(standardPayload.containsKey("parent"), is(false));
+    }
+
+    @Test
+    void shouldSendBuildsApiNotification() throws Exception {
+        StashNotifier notifier = buildsApiNotifier("PROJECT", "repository");
+        AbstractBuild<?, ?> run = mock(AbstractBuild.class);
+        AbstractProject<?, ?> job = mock(AbstractProject.class);
+        BuildListener listener = mock(BuildListener.class);
+        HttpNotifier httpNotifier = mock(HttpNotifier.class);
+        HttpNotifierSelector selector = mock(HttpNotifierSelector.class);
+        StashNotifier.DescriptorImpl globalDescriptor = mock(StashNotifier.DescriptorImpl.class);
+        NotificationResult expectedResult = NotificationResult.newSuccess();
+
+        doReturn(job).when(run).getParent();
+        when(job.getFullName()).thenReturn("folder/application/branch");
+        when(run.getExternalizableId()).thenReturn("folder/application/branch#1");
+        when(run.getWorkspace()).thenReturn(mock(FilePath.class));
+        when(listener.getLogger()).thenReturn(System.out);
+        when(httpNotifier.send(any(), any(), any(), any())).thenReturn(expectedResult);
+        when(selector.select(any())).thenReturn(httpNotifier);
+        doReturn(globalDescriptor).when(notifier).getGlobalDescriptor();
+        doReturn("build-key").when(notifier).getBuildKey(run, listener);
+        doReturn("folder/application").when(notifier).getBuildParent(run);
+        doReturn("PROJECT").when(notifier).expandValue(run, listener, "PROJECT");
+        doReturn("repository").when(notifier).expandValue(run, listener, "repository");
+        notifier.setHttpNotifierSelector(selector);
+        notifier.setStashServerBaseUrl("https://bitbucket.example");
+        notifier.setBuildName("build-name");
+        notifier.setBuildUrl("https://jenkins.example/job/1");
+        when(run.getDescription()).thenReturn("description");
+
+        NotificationResult actualResult = notifier.notifyStash(
+                System.out,
+                run,
+                "25a4b3c9",
+                listener,
+                StashBuildState.SUCCESSFUL);
+
+        ArgumentCaptor<URI> uri = ArgumentCaptor.forClass(URI.class);
+        ArgumentCaptor<JSONObject> payload = ArgumentCaptor.forClass(JSONObject.class);
+        verify(httpNotifier).send(uri.capture(), payload.capture(), any(), any());
+        assertThat(actualResult, is(expectedResult));
+        assertThat(uri.getValue(), equalTo(URI.create(
+                "https://bitbucket.example/rest/api/latest/projects/PROJECT/repos/repository/commits/25a4b3c9/builds")));
+        assertThat(payload.getValue().getString("parent"), is("folder/application"));
+    }
+
+    private StashNotifier buildsApiNotifier(String projectKey, String repositorySlug) {
+        StashNotifier notifier = newNotifier();
+        notifier.setUseBuildsApi(true);
+        notifier.setBitbucketProjectKey(projectKey);
+        notifier.setRepositorySlug(repositorySlug);
+        return notifier;
+    }
+
+    private StashNotifier newNotifier() {
+        return spy(new StashNotifier(
+                null,
+                null,
+                false,
+                null,
+                null,
+                null,
+                null,
+                false,
+                null,
+                false,
+                false,
+                false,
+                mock(JenkinsLocationConfiguration.class)));
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/stashNotifier/configuration-as-code-expected.yml
+++ b/src/test/resources/org/jenkinsci/plugins/stashNotifier/configuration-as-code-expected.yml
@@ -1,5 +1,6 @@
 considerUnstableAsSuccess: true
 credentialsId: "bitbucket-credentials"
+defaultUseBuildsApi: true
 disableInprogressNotification: true
 ignoreUnverifiedSsl: true
 includeBuildNumberInKey: true

--- a/src/test/resources/org/jenkinsci/plugins/stashNotifier/configuration-as-code.yml
+++ b/src/test/resources/org/jenkinsci/plugins/stashNotifier/configuration-as-code.yml
@@ -2,6 +2,7 @@ unclassified:
   notifyBitbucket:
     considerUnstableAsSuccess: true
     credentialsId: "bitbucket-credentials"
+    defaultUseBuildsApi: true
     disableInprogressNotification: true
     ignoreUnverifiedSsl: true
     includeBuildNumberInKey: true


### PR DESCRIPTION
Adds configurable Bitbucket Builds API support to the existing `notifyBitbucket` Pipeline step for compatiblity with the Required Builds merge check.

The updated step:

- supports the repository-scoped Builds API available in Bitbucket 7.4 or newer
- adds a global **Bitbucket build status API** setting with **Legacy** as the default and **Builds API (Bitbucket 7.4 or newer)** as the alternative
- allows to override the global setting for each `notifyBitbucket` invocation with `useBuildsApi: true / false`
- requires `bitbucketProjectKey` and `repositorySlug` when the Builds API is enabled
- includes the build `parent` expected by Required Builds, using the multibranch project path for multibranch jobs and the job path for regular jobs
- keeps the existing `notifyBitbucket` step, its configuration options, and the legacy endpoint unchanged when the Builds API is not enabled

PR also adds a Jenkins Pipeline integration test suite and runs it from GitHub Actions

<img width="807" height="448" alt="image" src="https://github.com/user-attachments/assets/22883d68-4f74-49a5-a231-b25326a8fad4" />

Fixes #429 #290

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md
You can override it by creating .github/pull_request_template.md in your own repository
-->
